### PR TITLE
Add writeVersion Gradle task

### DIFF
--- a/buildSrc/src/main/groovy/tanzawa.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tanzawa.java-conventions.gradle
@@ -112,3 +112,18 @@ task showTsubakuroManifest {
     }
 }
 
+task writeVersion(type: WriteProperties) {
+    description 'generate version file to META-INF/tsurugidb/{project.name}.properties'
+    inputs.property('Build-Revision', System.getenv("GITHUB_SHA") ?: "")
+    outputFile "${project.buildDir}/generated/version/META-INF/tsurugidb/${project.name}.properties"
+    properties (
+        'Build-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
+        'Build-Revision' : System.getenv("GITHUB_SHA") ?: "",
+        'Created-By'     : "Gradle ${gradle.gradleVersion}",
+        'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
+        'Build-OS'       : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+    )
+}
+
+sourceSets.main.output.dir("${project.buildDir}/generated/version")
+jar.dependsOn writeVersion


### PR DESCRIPTION
The `writeVersion` task is used to include version information in the jar file.