### PR TITLE
revise gradle plug-ins.

### DIFF
--- a/buildSrc/src/main/groovy/tanzawa.java-base.gradle
+++ b/buildSrc/src/main/groovy/tanzawa.java-base.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+}
+
+group = 'com.tsurugidb.tanzawa'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+ext {
+    tsubakuroVersion = '0.0.1-SNAPSHOT'
+    buildTimestamp = new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+    buildRevision = System.getenv("GITHUB_SHA") ?: ""
+    createdBy = "Gradle ${gradle.gradleVersion}"
+    buildJdk = "${javaToolchains.launcherFor(java.toolchain).get().getMetadata().javaRuntimeVersion} ${javaToolchains.launcherFor(java.toolchain).get().getMetadata().vendor} ${javaToolchains.launcherFor(java.toolchain).get().getMetadata().jvmVersion}"
+    buildOs = "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+}
+
+tasks.withType(JavaCompile) { task ->
+    task.options.encoding 'UTF-8'
+}
+
+tasks.withType(Javadoc) { task ->
+    task.options.encoding 'UTF-8'
+}

--- a/buildSrc/src/main/groovy/tanzawa.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tanzawa.java-conventions.gradle
@@ -1,15 +1,8 @@
 plugins {
-    id 'java'
+    id 'tanzawa.java-base'
     id 'checkstyle'
 
     id 'com.github.spotbugs'
-}
-
-group = 'com.tsurugidb.tanzawa'
-version = '0.0.1-SNAPSHOT'
-
-ext {
-    tsubakuroVersion = '0.0.1-SNAPSHOT'
 }
 
 if (hasProperty('mavenLocal')) {
@@ -44,9 +37,6 @@ configurations.all {
 }
 
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
-    }
     withSourcesJar()
 }
 
@@ -73,10 +63,6 @@ spotbugsMain {
 spotbugsTest.enabled = false
 checkstyleTest.enabled = false
 
-tasks.withType(JavaCompile) { task ->
-    task.options.encoding = 'UTF-8'
-}
-
 task testsJar(type: Jar) {
     classifier 'tests'
     from sourceSets.test.output
@@ -84,11 +70,11 @@ task testsJar(type: Jar) {
 
 jar {
     manifest.attributes (
-        'Build-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
-        'Build-Revision' : System.getenv("GITHUB_SHA") ?: "",
-        'Created-By'     : "Gradle ${gradle.gradleVersion}",
-        'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
-        'Build-OS'       : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+        'Build-Timestamp': buildTimestamp,
+        'Build-Revision' : buildRevision,
+        'Created-By'     : createdBy,
+        'Build-Jdk'      : buildJdk,
+        'Build-OS'       : buildOs,
     )
 }
 
@@ -114,16 +100,16 @@ task showTsubakuroManifest {
 
 task writeVersion(type: WriteProperties) {
     description 'generate version file to META-INF/tsurugidb/{project.name}.properties'
-    inputs.property('Build-Revision', System.getenv("GITHUB_SHA") ?: "")
+    inputs.property('Build-Revision', buildRevision)
     outputFile "${project.buildDir}/generated/version/META-INF/tsurugidb/${project.name}.properties"
     properties (
-        'Build-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
-        'Build-Revision' : System.getenv("GITHUB_SHA") ?: "",
-        'Created-By'     : "Gradle ${gradle.gradleVersion}",
-        'Build-Jdk'      : "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
-        'Build-OS'       : "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
+        'Build-Timestamp': buildTimestamp,
+        'Build-Revision' : buildRevision,
+        'Created-By'     : createdBy,
+        'Build-Jdk'      : buildJdk,
+        'Build-OS'       : buildOs,
     )
 }
 
 sourceSets.main.output.dir("${project.buildDir}/generated/version")
-jar.dependsOn writeVersion
+processResources.dependsOn writeVersion

--- a/buildSrc/src/main/groovy/tanzawa.javadocs.gradle
+++ b/buildSrc/src/main/groovy/tanzawa.javadocs.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'tanzawa.java-base'
 }
 
 tasks.register('allJavadoc', Javadoc)
@@ -10,4 +10,3 @@ tasks.named('allJavadoc') {
     title = "Tanzawa All JavaDoc"
     options.links "https://docs.oracle.com/en/java/javase/11/docs/api/"
 }
-


### PR DESCRIPTION
This PR reorganize internal Gradle plug-ins under `buildSrc`.

* introduce `tanzawa.java-base`
* extract build setting information to `ext`
* specify Javadoc encoding
