### PR TITLE
Fixed small typo in help message

### DIFF
--- a/modules/core/src/main/resources/com/tsurugidb/console/help.properties
+++ b/modules/core/src/main/resources/com/tsurugidb/console/help.properties
@@ -62,10 +62,10 @@ READ ONLY IMMEDIATE - same to "READ ONLY".\n\
 READ ONLY DEFERRABLE - the transaction never insert/update/delete any rows, may retrieve not fresh rows.\n\
 WRITE PRESERVE <table-name> [, ...] - declares insert/update/delete target tables, if this is specified,\n\
 \                                      the transaction cannot modify other tables.\n\
-READ AREA INCLUDE - <table-name> [, ...] - declares referring (select/insert/update/delete) tables,\n\
-\                                           if this is specified, the transaction cannot touch other tables.\n\
-READ AREA EXCULUDE - <table-name> [, ...] - declares NEVER referring (select/insert/update/delete) tables,\n\
-\                                            if this is specified, the transaction cannot touch those tables.\n\
+READ AREA INCLUDE <table-name> [, ...] - declares referring (select/insert/update/delete) tables,\n\
+\                                         if this is specified, the transaction cannot touch other tables.\n\
+READ AREA EXCULUDE <table-name> [, ...] - declares NEVER referring (select/insert/update/delete) tables,\n\
+\                                          if this is specified, the transaction cannot touch those tables.\n\
 EXECUTE PRIOR - executes this transaction prior to any other transactions.\n\
 \                If there are running transactions are available, this transaction will start after the running\n\
 \                transactions will have been finished.\n\


### PR DESCRIPTION
`\help` 中に余計な `-` があったので消しました。