### PR TITLE
Change host cache dir for Gradle

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,7 +15,7 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GHCR_PAT }}
       volumes:
-        - /work/docker-cache/.gradle:/root/.gradle
+        - ${{ vars.gradle_cache_dir }}:/root/.gradle
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Gradle用のキャッシュディレクトリを変更します。その他、いくつかの細かいCIワークフローの改善を入れています。