### PR TITLE
Modify Gradle config for distribution

### DIFF
--- a/modules/cli/build.gradle
+++ b/modules/cli/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 application {
     applicationName = 'tgsql'
     mainClass = 'com.tsurugidb.console.cli.Main'
+    applicationDefaultJvmArgs = ['-Dcom.tsurugidb.tsubakuro.jniverify=false']
 }
 
 run {
@@ -40,4 +41,8 @@ shadowJar {
     archiveBaseName = 'sql-console'
     archiveClassifier = 'all'
     mergeServiceFiles()
+}
+
+distZip {
+    archiveFileName = "tgsql.zip"
 }


### PR DESCRIPTION
`distZip` タスクで生成されるアーカイブファイル名を `tgsql.zip` に変更します。
その他、デフォルトのシステムプロパティを他のJavaプロジェクトと共通のものを設定。
