### PR TITLE
introduce SqlParser.Options to skip comments.

### DIFF
--- a/modules/core/src/main/java/com/tsurugidb/console/core/parser/Segment.java
+++ b/modules/core/src/main/java/com/tsurugidb/console/core/parser/Segment.java
@@ -111,10 +111,10 @@ class Segment {
          */
         void addToken(@Nonnull TokenInfo token) {
             if (LOG.isTraceEnabled()) {
-                LOG.trace("token: kind={}, position={}, delimiter={}, line={}, column={}, text={}", new Object[] { //$NON-NLS-1$
+                LOG.trace("token: kind={}, position={}, category={}, line={}, column={}, text={}", new Object[] { //$NON-NLS-1$
                         token.getKind(),
                         offset + token.getOffset(),
-                        token.getKind().isStatementDelimiter(),
+                        token.getKind().getCategory(),
                         token.getStartLine(),
                         token.getStartColumn(),
                         getText(token).map(it -> "'" + it + "'").orElse("N/A") //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
@@ -162,7 +162,7 @@ class Segment {
         private void normalizeDelimiter() {
             if (!tokens.isEmpty()) {
                 var last = tokens.get(tokens.size() - 1);
-                if (last.getKind().isStatementDelimiter()) {
+                if (last.getKind().getCategory() == TokenCategory.DELIMITER) {
                     tokens.set(tokens.size() - 1, new TokenInfo(
                             TokenKind.END_OF_STATEMENT,
                             last.getOffset(),

--- a/modules/core/src/main/java/com/tsurugidb/console/core/parser/SqlParser.java
+++ b/modules/core/src/main/java/com/tsurugidb/console/core/parser/SqlParser.java
@@ -16,6 +16,75 @@ import com.tsurugidb.console.core.model.Statement;
  */
 public class SqlParser implements Closeable {
 
+    /**
+     * Options of {@link SqlParser}.
+     */
+    public static class Options {
+
+        /**
+         * The default value of {@link #withSkipComments(boolean)} ({@value #DEFAULT_SKIP_COMMENTS}).
+         */
+        public static final boolean DEFAULT_SKIP_COMMENTS = SqlScanner.Options.DEFAULT_SKIP_COMMENTS;
+
+        private final SqlScanner.Options scannerOpts = new SqlScanner.Options();
+
+        /**
+         * Sets whether or not skip comment tokens.
+         * @param enabled {@code true} to skip comments, or {@code false} to treat comments as tokens
+         * @return this
+         * @see #DEFAULT_SKIP_COMMENTS
+         */
+        public Options withSkipComments(boolean enabled) {
+            this.scannerOpts.skipComments = enabled;
+            return this;
+        }
+
+        /**
+         * Returns whether or not skip comment tokens.
+         * @return {@code true} to skip comments, or {@code false} to treat comments as tokens
+         * @see #DEFAULT_SKIP_COMMENTS
+         */
+        public boolean isSkipComments() {
+            return this.scannerOpts.skipComments;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((scannerOpts == null) ? 0 : scannerOpts.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Options other = (Options) obj;
+            if (scannerOpts == null) {
+                if (other.scannerOpts != null) {
+                    return false;
+                }
+            } else if (!scannerOpts.equals(other.scannerOpts)) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("{skipComments:%s}", //$NON-NLS-1$
+                    scannerOpts.skipComments);
+        }
+    }
+
     private final SqlScanner scanner;
 
     /**
@@ -25,6 +94,17 @@ public class SqlParser implements Closeable {
     public SqlParser(@Nonnull Reader input) {
         Objects.requireNonNull(input);
         this.scanner = new SqlScanner(input);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param input the input source
+     * @param options the parser options
+     */
+    public SqlParser(@Nonnull Reader input, @Nonnull Options options) {
+        Objects.requireNonNull(input);
+        Objects.requireNonNull(options);
+        this.scanner = new SqlScanner(input, options.scannerOpts);
     }
 
     /**

--- a/modules/core/src/main/java/com/tsurugidb/console/core/parser/SqlScanner.java
+++ b/modules/core/src/main/java/com/tsurugidb/console/core/parser/SqlScanner.java
@@ -12,15 +12,63 @@ import javax.annotation.Nonnull;
  */
 class SqlScanner implements Closeable {
 
+    /**
+     * Options of {@link SqlScanner}.
+     */
+    static class Options {
+
+        static final boolean DEFAULT_SKIP_COMMENTS = false;
+
+        boolean skipComments = DEFAULT_SKIP_COMMENTS;
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + (skipComments ? 1231 : 1237);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Options other = (Options) obj;
+            if (skipComments != other.skipComments) {
+                return false;
+            }
+            return true;
+        }
+    }
+
     private final SqlScannerFlex flex;
+
+    /**
+     * Creates a new instance with default options.
+     * @param input the input
+     */
+    SqlScanner(@Nonnull Reader input) {
+        this(input, new Options());
+    }
 
     /**
      * Creates a new instance.
      * @param input the input
+     * @param options the scanner options
      */
-    SqlScanner(@Nonnull Reader input) {
+    SqlScanner(@Nonnull Reader input, @Nonnull Options options) {
         Objects.requireNonNull(input);
-        flex = new SqlScannerFlex(input);
+        Objects.requireNonNull(options);
+        flex = new SqlScannerFlex(
+                input,
+                options.skipComments);
     }
 
     /**

--- a/modules/core/src/main/java/com/tsurugidb/console/core/parser/TokenCategory.java
+++ b/modules/core/src/main/java/com/tsurugidb/console/core/parser/TokenCategory.java
@@ -1,0 +1,34 @@
+package com.tsurugidb.console.core.parser;
+
+enum TokenCategory {
+
+    /**
+     * Unknown tokens.
+     */
+    UNKNOWN,
+
+    /**
+     * Comments.
+     */
+    COMMENT,
+
+    /**
+     * Regular tokens.
+     */
+    REGULAR,
+
+    /**
+     * Punctuation.
+     */
+    PUNCTUATION,
+
+    /**
+     * Statement delimiters.
+     */
+    DELIMITER,
+
+    /**
+     * Pseudo tokens.
+     */
+    PSEUDO,
+}

--- a/modules/core/src/main/java/com/tsurugidb/console/core/parser/TokenKind.java
+++ b/modules/core/src/main/java/com/tsurugidb/console/core/parser/TokenKind.java
@@ -4,162 +4,159 @@ enum TokenKind {
     /**
      * End-Of-File.
      */
-    EOF(true),
+    EOF(TokenCategory.DELIMITER),
 
     /**
      * text segment which the parser cannot handle.
      */
-    UNHANDLED_TEXT,
+    UNHANDLED_TEXT(TokenCategory.UNKNOWN),
 
     /**
      * regular (unquoted) identifiers.
      */
-    REGULAR_IDENTIFIER,
+    REGULAR_IDENTIFIER(TokenCategory.REGULAR),
 
     /**
      * delimited identifiers.
      */
-    DELIMITED_IDENTIFIER,
+    DELIMITED_IDENTIFIER(TokenCategory.REGULAR),
 
     // literals
 
     /**
      * numeric literals.
      */
-    NUMERIC_LITERAL,
+    NUMERIC_LITERAL(TokenCategory.REGULAR),
 
     /**
      * true.
      */
-    TRUE_LITERAL,
+    TRUE_LITERAL(TokenCategory.REGULAR),
 
     /**
      * false.
      */
-    FALSE_LITERAL,
+    FALSE_LITERAL(TokenCategory.REGULAR),
 
     /**
      * null.
      */
-    NULL_LITERAL,
+    NULL_LITERAL(TokenCategory.REGULAR),
 
     /**
      * character string literals.
      */
-    CHARACTER_STRING_LITERAL,
+    CHARACTER_STRING_LITERAL(TokenCategory.REGULAR),
 
     /**
      * binary string literals.
      */
-    BINARY_STRING_LITERAL,
+    BINARY_STRING_LITERAL(TokenCategory.REGULAR),
 
     // punctuation
 
     /**
      * dot.
      */
-    DOT,
+    DOT(TokenCategory.PUNCTUATION),
 
     /**
      * comma.
      */
-    COMMA,
+    COMMA(TokenCategory.PUNCTUATION),
 
     /**
      * semicolon.
      */
-    SEMICOLON(true),
+    SEMICOLON(TokenCategory.DELIMITER),
 
     /**
      * open paren.
      */
-    LEFT_PAREN,
+    LEFT_PAREN(TokenCategory.PUNCTUATION),
 
     /**
      * close paren.
      */
-    RIGHT_PAREN,
+    RIGHT_PAREN(TokenCategory.PUNCTUATION),
 
     // operators
 
     /**
      * plus sign.
      */
-    PLUS,
+    PLUS(TokenCategory.PUNCTUATION),
 
     /**
      * minus sign.
      */
-    MINUS,
+    MINUS(TokenCategory.PUNCTUATION),
 
     /**
      * asterisk.
      */
-    ASTERISK,
+    ASTERISK(TokenCategory.PUNCTUATION),
 
     /**
      * equal sign.
      */
-    EQUAL,
+    EQUAL(TokenCategory.PUNCTUATION),
 
     /**
      * bare back-slash sign.
      */
-    BACK_SLASH,
+    BACK_SLASH(TokenCategory.PUNCTUATION),
 
     /**
      * special command name.
      */
-    SPECIAL_COMMAND,
+    SPECIAL_COMMAND(TokenCategory.REGULAR),
 
     /**
      * special command argument.
      */
-    SPECIAL_COMMAND_ARGUMENT,
+    SPECIAL_COMMAND_ARGUMENT(TokenCategory.REGULAR),
 
     /**
      * line break in special command.
      */
-    LINE_BREAK(true),
+    LINE_BREAK(TokenCategory.DELIMITER),
 
     // comments
 
     /**
      * C-style comment block.
      */
-    BLOCK_COMMENT,
+    BLOCK_COMMENT(TokenCategory.COMMENT),
 
     /**
      * comments leading two slashes.
      */
-    SLASH_COMMENT,
+    SLASH_COMMENT(TokenCategory.COMMENT),
 
     /**
      * comments leading two hyphens.
      */
-    HYPHEN_COMMENT,
+    HYPHEN_COMMENT(TokenCategory.COMMENT),
 
     /**
      * pseudo-symbol of end of statement.
      */
-    END_OF_STATEMENT,
+    END_OF_STATEMENT(TokenCategory.PSEUDO),
 
     ;
-    private final boolean statementDelimiter;
+    private final TokenCategory category;
 
-    TokenKind() {
-        statementDelimiter = false;
-    }
-
-    TokenKind(boolean statementDelimiter) {
-        this.statementDelimiter = statementDelimiter;
+    TokenKind(TokenCategory category) {
+        assert category != null;
+        this.category = category;
     }
 
     /**
-     * Returns whether or not the token is a statement delimiter.
-     * @return whether or not the token is a statement delimiter
+     * Returns the category of this token.
+     * @return the token category
      */
-    public boolean isStatementDelimiter() {
-        return statementDelimiter;
+    public TokenCategory getCategory() {
+        return category;
     }
 }

--- a/modules/core/src/main/jflex/SqlScanner.jflex
+++ b/modules/core/src/main/jflex/SqlScanner.jflex
@@ -16,6 +16,11 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
     return eof();
 %eofval}
 
+%ctorarg boolean skipComments
+%init{
+    this.skipComments = skipComments;
+%init}
+
 %char
 %line
 %column
@@ -27,7 +32,9 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
     static final int SAW_BODY = 1;
 
-    private Segment.Builder buffer = new Segment.Builder();
+    private boolean skipComments;
+
+    private final Segment.Builder buffer = new Segment.Builder();
 
     private boolean textContinue = false;
     private int textStartLine = -1;
@@ -48,11 +55,14 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
     }
 
     private int token(TokenKind kind) {
+        if (skipComments && kind.getCategory() == TokenCategory.COMMENT) {
+            return skip();
+        }
         initialize();
         flushUnhandled();
         appendText();
         buffer.addToken(new TokenInfo(kind, buffer.relative(yychar), yylength(), yyline, yycolumn));
-        if (kind.isStatementDelimiter()) {
+        if (kind.getCategory() == TokenCategory.DELIMITER) {
             return SAW_DELIMITER;
         }
         return SAW_BODY;

--- a/modules/core/src/test/java/com/tsurugidb/console/core/parser/SqlParserTest.java
+++ b/modules/core/src/test/java/com/tsurugidb/console/core/parser/SqlParserTest.java
@@ -56,16 +56,44 @@ class SqlParserTest {
         assertEquals(Statement.Kind.EMPTY, ss.get(0).getKind());
     }
 
+    @Test
+    void comments() throws Exception {
+        var ss = parse("-- comment\nSELECT * FROM T");
+        assertEquals(1, ss.size());
+        assertEquals(Statement.Kind.GENERIC, ss.get(0).getKind());
+        assertEquals("-- comment\nSELECT * FROM T", ss.get(0).getText());
+    }
+
+    @Test
+    void comments_skip() throws Exception {
+        var opts = new SqlParser.Options()
+                .withSkipComments(true);
+        var ss = parse(opts, "-- comment\nSELECT * FROM T");
+        assertEquals(1, ss.size());
+        assertEquals(Statement.Kind.GENERIC, ss.get(0).getKind());
+        assertEquals("SELECT * FROM T", ss.get(0).getText());
+    }
+
     private static List<Statement> parse(String text) throws IOException {
-        List<Statement> results = new ArrayList<>();
         try (var parser = new SqlParser(new StringReader(text))) {
-            while (true) {
-                var s = parser.next();
-                if (s == null) {
-                    break;
-                }
-                results.add(s);
+            return parse0(parser);
+        }
+    }
+
+    private static List<Statement> parse(SqlParser.Options opts, String text) throws IOException {
+        try (var parser = new SqlParser(new StringReader(text), opts)) {
+            return parse0(parser);
+        }
+    }
+
+    private static List<Statement> parse0(SqlParser parser) throws IOException {
+        List<Statement> results = new ArrayList<>();
+        while (true) {
+            var s = parser.next();
+            if (s == null) {
+                break;
             }
+            results.add(s);
         }
         return results;
     }


### PR DESCRIPTION
This PR introduces `SqlParser` options, including `skipComments` - the parser treats comments as like white-spaces.

related to https://github.com/project-tsurugi/tsurugi-issues/issues/437.

## example

```java
var opts = new SqlParser.Options()
        .withSkipComments(true);

try (
    var reader = ...;
    var parser = new SqlParser(reader, opts);
) {
    ...
}
```
