### PR TITLE
Enable `tgdump --profile PG-Strom`.

### DIFF
--- a/docs/tgdump-design_ja.md
+++ b/docs/tgdump-design_ja.md
@@ -285,14 +285,33 @@ tgdump <table-name> [<table-name> [...]] --to </path/to/destination-dir> --conne
   フィールド名 | 形式 | 概要
   ------------|------|------
   `format_type` | 文字列 | `"parquet"`
+  `parquet_version` | 文字列 | Parquet file 形式のバージョン
+  `record_batch_size` | 整数 | row group の最大行数, 1以上
+  `record_batch_in_bytes` | 整数 | row group の最大行数を推定レコードサイズから算定, 1以上
+  `codec` | 文字列 | 圧縮コーデックの名前
+  `encoding` | 文字列 | 列のエンコーディングの名前
+  `columns` | 配列 | 列ごとの設定 (後述)
+
+  上記の `columns` フィールドには、以下のプロパティを有する JSON オブジェクトを指定する (`ParquetColumnFormat` に対応)。
+
+  フィールド名 | 形式 | 概要
+  ------------|------|------
+  `name` | 文字列 | 対象の列名
+  `codec` | 文字列 | 圧縮コーデックの名前
+  `encoding` | 文字列 | 列のエンコーディングの名前
 
   Apache Arrow 形式の場合、 `file_format` には以下のプロパティを有する JSON オブジェクトを指定する (`ArrowFileFormat` に対応)。
 
   フィールド名 | 形式 | 概要
   ------------|------|------
   `format_type` | 文字列 | `"arrow"`
-
-  TODO: protocol buffers の変更に合わせて、上記を追従させる
+  `metadata_version` | 文字列 | メタデータ形式のバージョン
+  `alignment` | 整数 | メモリアライメントのバイト数, 1以上
+  `record_batch_size` | 整数 | record batch の最大行数, 1以上
+  `record_batch_in_bytes` | 整数 | record batch の最大行数を推定レコードサイズから算定, 1以上
+  `codec` | 文字列 | 圧縮コーデックの名前
+  `min_space_saving` | 数値 | 圧縮済みデータを採用する圧縮率の閾値, 0.0~1.0の範囲
+  `character_field_type` | 文字列 | `"STRING"` または `"FIXED_SIZE_BINARY"`
 
 * ダンププロファイル記述ファイルを組み込みのダンププロファイルとする場合、以下の手順を行う
   1. クラスパス上に当該ファイルを配置する

--- a/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ArrowFileFormat.java
+++ b/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ArrowFileFormat.java
@@ -1,8 +1,14 @@
 package com.tsurugidb.tools.tgdump.core.model;
 
+import java.text.MessageFormat;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.tsurugidb.sql.proto.SqlRequest;
 
@@ -12,9 +18,132 @@ import com.tsurugidb.sql.proto.SqlRequest;
 public class ArrowFileFormat implements DumpFileFormat {
 
     /**
+     * {@code CHAR} column metadata type.
+     */
+    public enum CharacterFieldType {
+
+        /**
+         * use {@code StringBuilder} for {@code CHAR} columns.
+         */
+        STRING,
+
+        /**
+         * use {@code FixedSizeBinaryBuilder} for {@code CHAR} columns.
+         */
+        FIXED_SIZE_BINARY,
+    }
+
+    /**
      * A builder of {@link ArrowFileFormat}.
      */
     public static class Builder {
+
+        @Nullable String metadataVersion;
+
+        @Nullable Integer alignment;
+
+        @Nullable Long recordBatchSize;
+
+        @Nullable Long recordBatchInBytes;
+
+        @Nullable String codec;
+
+        @Nullable Double minSpaceSaving;
+
+        @Nullable CharacterFieldType characterFieldType;
+
+        /**
+         * Sets the metadata format version.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withMetadataVersion(@Nullable String value) {
+            this.metadataVersion = normalize(value);
+            return this;
+        }
+
+        /**
+         * Sets the byte alignment of each values.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         * @throws IllegalArgumentException if the value is less than {@code 1}
+         */
+        public Builder withAlignment(@Nullable Integer value) {
+            if (value != null && value < 1) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "alignment size must be >= 1 ({0})",
+                        value));
+            }
+            this.alignment = value;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of records in record batch.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         * @throws IllegalArgumentException if the value is less than {@code 1}
+         */
+        public Builder withRecordBatchSize(@Nullable Long value) {
+            if (value != null && value < 1) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "record batch size must be >= 1 ({0})",
+                        value));
+            }
+            this.recordBatchSize = value;
+            return this;
+        }
+
+        /**
+         * Sets the approximately maximum size of each record batch in bytes.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         * @throws IllegalArgumentException if the value is less than {@code 1}
+         */
+        public Builder withRecordBatchInBytes(@Nullable Long value) {
+            if (value != null && value < 1) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "record batch size must be >= 1 ({0})",
+                        value));
+            }
+            this.recordBatchInBytes = value;
+            return this;
+        }
+
+        /**
+         * Sets the compression codec name.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withCodec(@Nullable String value) {
+            this.codec = normalize(value);
+            return this;
+        }
+
+        /**
+         * Sets threshold for adopting compressed data.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withMinSpaceSaving(@Nullable Double value) {
+            if (value != null && (value < 0.0 || value > 1.0)) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "min space saving must be in range [0.0, 1.0] ({0})",
+                        value));
+            }
+            this.minSpaceSaving = value;
+            return this;
+        }
+
+        /**
+         * Sets encoding type for {@code CHAR} columns.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withCharacterFieldType(@Nullable CharacterFieldType value) {
+            this.characterFieldType = value;
+            return this;
+        }
 
         /**
          * Creates a new instance from this builder settings.
@@ -23,7 +152,28 @@ public class ArrowFileFormat implements DumpFileFormat {
         public ArrowFileFormat build() {
             return new ArrowFileFormat(this);
         }
+
+        private static @Nullable String normalize(@Nullable String value) {
+            if (value == null || value.isEmpty()) {
+                return null;
+            }
+            return value;
+        }
     }
+
+    private final @Nullable String metadataVersion;
+
+    private final @Nullable Integer alignment;
+
+    private final @Nullable Long recordBatchSize;
+
+    private final @Nullable Long recordBatchInBytes;
+
+    private final @Nullable String codec;
+
+    private final @Nullable Double minSpaceSaving;
+
+    private final @Nullable CharacterFieldType characterFieldType;
 
     /**
      * Creates a new instance with default settings.
@@ -40,6 +190,13 @@ public class ArrowFileFormat implements DumpFileFormat {
      */
     public ArrowFileFormat(@Nonnull Builder builder) {
         Objects.requireNonNull(builder);
+        this.metadataVersion = builder.metadataVersion;
+        this.alignment = builder.alignment;
+        this.recordBatchSize = builder.recordBatchSize;
+        this.recordBatchInBytes = builder.recordBatchInBytes;
+        this.codec = builder.codec;
+        this.minSpaceSaving = builder.minSpaceSaving;
+        this.characterFieldType = builder.characterFieldType;
     }
 
     /**
@@ -55,14 +212,72 @@ public class ArrowFileFormat implements DumpFileFormat {
         return FormatType.ARROW;
     }
 
+    /**
+     * Returns the metadata format version.
+     * @return the metadata format version, or {@code empty} if it is not defined
+     */
+    public Optional<String> getMetadataVersion() {
+        return Optional.ofNullable(metadataVersion);
+    }
+
+    /**
+     * Returns the byte alignment of each values.
+     * @return the byte alignment of each values, or {@code empty} if it is not defined
+     */
+    public OptionalInt getAlignment() {
+        return wrap(alignment);
+    }
+
+    /**
+     * Returns the maximum number of records in record batch.
+     * @return the record batch size, or {@code empty} if it is not defined
+     */
+    public OptionalLong getRecordBatchSize() {
+        return wrap(recordBatchSize);
+    }
+
+    /**
+     * Returns the approximately maximum size of each record batch in bytes.
+     * @return the record batch size in estimated record size, or {@code empty} if it is not defined
+     */
+    public OptionalLong getRecordBatchInBytes() {
+        return wrap(recordBatchInBytes);
+    }
+
+    /**
+     * Returns the compression codec name.
+     * @return the compression codec name, or {@code empty} if it is not defined
+     */
+    public Optional<String> getCodec() {
+        return Optional.ofNullable(codec);
+    }
+
+    /**
+     * Returns threshold for adopting compressed data.
+     * @return threshold for adopting compressed data, or {@code empty} if it is not defined
+     */
+    public OptionalDouble getMinSpaceSaving() {
+        return wrap(minSpaceSaving);
+    }
+
+    /**
+     * Returns {@code CHAR} column metadata type.
+     * @return {@code CHAR} column metadata type, or {@code empty} if it is not defined
+     */
+    public Optional<CharacterFieldType> getCharacterFieldType() {
+        return Optional.ofNullable(characterFieldType);
+    }
+
     @Override
     public SqlRequest.ArrowFileFormat toProtocolBuffer() {
+        // FIXME: impl
         return SqlRequest.ArrowFileFormat.getDefaultInstance();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(FormatType.ARROW);
+        return Objects.hash(alignment, characterFieldType, codec, metadataVersion, minSpaceSaving, recordBatchInBytes,
+                recordBatchSize);
     }
 
     @Override
@@ -76,12 +291,43 @@ public class ArrowFileFormat implements DumpFileFormat {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        return true;
+        ArrowFileFormat other = (ArrowFileFormat) obj;
+        return Objects.equals(alignment, other.alignment)
+                && characterFieldType == other.characterFieldType
+                && Objects.equals(codec, other.codec)
+                && Objects.equals(metadataVersion, other.metadataVersion)
+                && Objects.equals(minSpaceSaving, other.minSpaceSaving)
+                && Objects.equals(recordBatchInBytes, other.recordBatchInBytes)
+                && Objects.equals(recordBatchSize, other.recordBatchSize);
     }
 
     @Override
     public String toString() {
-        // FIXME: more fields
-        return "ArrowFileFormat()";
+        return String.format(
+                "ArrowFileFormat(metadataVersion=%s,alignment=%s, recordBatchSize=%s, recordBatchInBytes=%s, " //$NON-NLS-1$
+                + "codec=%s, minSpaceSaving=%s, characterFieldType=%s)", //$NON-NLS-1$
+                metadataVersion, alignment, recordBatchSize, recordBatchInBytes,
+                codec, minSpaceSaving, characterFieldType);
+    }
+
+    private static OptionalInt wrap(@Nullable Integer value) {
+        if (value == null) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(value);
+    }
+
+    private static OptionalLong wrap(@Nullable Long value) {
+        if (value == null) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(value);
+    }
+
+    private static OptionalDouble wrap(@Nullable Double value) {
+        if (value == null) {
+            return OptionalDouble.empty();
+        }
+        return OptionalDouble.of(value);
     }
 }

--- a/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/DumpProfile.java
+++ b/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/DumpProfile.java
@@ -145,7 +145,7 @@ public class DumpProfile {
      * This may returns {@code empty} even if {@link #getDescription() non-localized description} exists.
      * </p>
      * @param language the language code for the description
-     * @return the localized profile description, or {@code empty} if it is not sure
+     * @return the localized profile description for the language, or {@code empty} if it is not sure
      */
     public Optional<String> getLocalizedDescription(@Nonnull String language) {
         Objects.requireNonNull(language);

--- a/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ParquetColumnFormat.java
+++ b/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ParquetColumnFormat.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.tsurugidb.sql.proto.SqlRequest;
+
 /**
  * A format description of individual columns in {@link ParquetFileFormat}.
  */
@@ -136,7 +138,17 @@ public class ParquetColumnFormat {
         return Optional.ofNullable(encoding);
     }
 
-    // TODO: SqlRequest.ParquetColumnFormat toProtocolBuffer()
+    /**
+     * Builds dump options from this settings.
+     * @return the built protocol buffer object
+     */
+    public SqlRequest.ParquetColumnFormat toProtocolBuffer() {
+        var builder = SqlRequest.ParquetColumnFormat.newBuilder();
+        builder.setName(getName());
+        getCodec().ifPresent(builder::setCodec);
+        getEncoding().ifPresent(builder::setEncoding);
+        return builder.build();
+    }
 
     @Override
     public int hashCode() {

--- a/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ParquetColumnFormat.java
+++ b/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ParquetColumnFormat.java
@@ -1,0 +1,167 @@
+package com.tsurugidb.tools.tgdump.core.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * A format description of individual columns in {@link ParquetFileFormat}.
+ */
+public class ParquetColumnFormat {
+
+    /**
+     * A builder of {@link ParquetColumnFormat}.
+     */
+    public static class Builder {
+
+        final String name;
+
+        @Nullable String codec;
+
+        @Nullable String encoding;
+
+        /**
+         * Creates a new instance.
+         * @param name the target column name
+         */
+        public Builder(@Nonnull String name) {
+            Objects.requireNonNull(name);
+            this.name = name;
+        }
+
+        /**
+         * Sets common compression codec name of the individual columns.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withCodec(@Nullable String value) {
+            this.codec = normalize(value);
+            return this;
+        }
+
+        /**
+         * Sets common encoding type of the individual columns.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withEncoding(@Nullable String value) {
+            this.encoding = normalize(value);
+            return this;
+        }
+
+        /**
+         * Creates a new instance from this builder settings.
+         * @return the created instance
+         */
+        public ParquetColumnFormat build() {
+            return new ParquetColumnFormat(this);
+        }
+
+        private static @Nullable String normalize(@Nullable String value) {
+            if (value == null || value.isEmpty()) {
+                return null;
+            }
+            return value;
+        }
+    }
+
+    private final @Nullable String name;
+
+    private final @Nullable String codec;
+
+    private final @Nullable String encoding;
+
+    /**
+     * Creates a new instance with default settings.
+     * @param name the target column name
+     * @see #newBuilder(String)
+     */
+    public ParquetColumnFormat(@Nonnull String name) {
+        this(new Builder(name));
+    }
+
+    /**
+     * Creates a new instance from the builder.
+     * @param builder the source builder
+     * @see #newBuilder(String)
+     */
+    public ParquetColumnFormat(@Nonnull Builder builder) {
+        Objects.requireNonNull(builder);
+        this.name = builder.name;
+        this.codec = builder.codec;
+        this.encoding = builder.encoding;
+    }
+
+    /**
+     * Creates a new builder object for this class.
+     * @param name the target column name
+     * @return the created builder object
+     */
+    public static Builder newBuilder(@Nonnull String name) {
+        return new Builder(name);
+    }
+
+    /**
+     * Creates a new builder object for this class.
+     * @param name the target column name
+     * @return the created builder object
+     */
+    public static Builder forColumn(@Nonnull String name) {
+        return newBuilder(name);
+    }
+
+    /**
+     * Returns the target column name.
+     * @return the target column name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the compression codec name for this column.
+     * @return the compression codec name, or {@code empty} if it is not defined
+     */
+    public Optional<String> getCodec() {
+        return Optional.ofNullable(codec);
+    }
+
+    /**
+     * Returns the common encoding type for this column.
+     * @return the common encoding type, or {@code empty} if it is not defined
+     */
+    public Optional<String> getEncoding() {
+        return Optional.ofNullable(encoding);
+    }
+
+    // TODO: SqlRequest.ParquetColumnFormat toProtocolBuffer()
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, codec, encoding);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ParquetColumnFormat other = (ParquetColumnFormat) obj;
+        return Objects.equals(name, other.name)
+                && Objects.equals(codec, other.codec)
+                && Objects.equals(encoding, other.encoding);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ParquetColumnFormat(name=%s, codec=%s, encoding=%s)", name, codec, encoding); //$NON-NLS-1$
+    }
+}

--- a/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ParquetFileFormat.java
+++ b/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ParquetFileFormat.java
@@ -1,8 +1,14 @@
 package com.tsurugidb.tools.tgdump.core.model;
 
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.tsurugidb.sql.proto.SqlRequest;
 
@@ -16,6 +22,93 @@ public class ParquetFileFormat implements DumpFileFormat {
      */
     public static class Builder {
 
+        @Nullable String parquetVersion;
+
+        @Nullable Long recordBatchSize;
+
+        @Nullable Long recordBatchInBytes;
+
+        @Nullable String codec;
+
+        @Nullable String encoding;
+
+        final List<ParquetColumnFormat> columns = new ArrayList<>();
+
+        /**
+         * Sets the parquet file format version.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withParquetVersion(@Nullable String value) {
+            this.parquetVersion = normalize(value);
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of rows in the same row group.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         * @throws IllegalArgumentException if the value is less than {@code 1}
+         */
+        public Builder withRecordBatchSize(@Nullable Long value) {
+            if (value != null && value < 1) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "record batch size must be >= 1 ({0})",
+                        value));
+            }
+            this.recordBatchSize = value;
+            return this;
+        }
+
+        /**
+         * Sets the approximately maximum row group size in bytes.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         * @throws IllegalArgumentException if the value is less than {@code 1}
+         */
+        public Builder withRecordBatchInBytes(@Nullable Long value) {
+            if (value != null && value < 1) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "record batch size must be >= 1 ({0})",
+                        value));
+            }
+            this.recordBatchInBytes = value;
+            return this;
+        }
+
+        /**
+         * Sets common compression codec name of the individual columns.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withCodec(@Nullable String value) {
+            this.codec = normalize(value);
+            return this;
+        }
+
+        /**
+         * Sets common encoding type of the individual columns.
+         * @param value the value to set, or {@code null} to clear it
+         * @return this
+         */
+        public Builder withEncoding(@Nullable String value) {
+            this.encoding = normalize(value);
+            return this;
+        }
+
+        /**
+         * Sets column specific settings.
+         * @param values the values to set
+         * @return this
+         * @see ParquetColumnFormat#forColumn(String)
+         */
+        public Builder withColumns(@Nonnull List<? extends ParquetColumnFormat> values) {
+            Objects.requireNonNull(values);
+            this.columns.clear();
+            this.columns.addAll(values);
+            return this;
+        }
+
         /**
          * Creates a new instance from this builder settings.
          * @return the created instance
@@ -23,7 +116,26 @@ public class ParquetFileFormat implements DumpFileFormat {
         public ParquetFileFormat build() {
             return new ParquetFileFormat(this);
         }
+
+        private static @Nullable String normalize(@Nullable String value) {
+            if (value == null || value.isEmpty()) {
+                return null;
+            }
+            return value;
+        }
     }
+
+    private final @Nullable String parquetVersion;
+
+    private final @Nullable Long recordBatchSize;
+
+    private final @Nullable Long recordBatchInBytes;
+
+    private final @Nullable String codec;
+
+    private final @Nullable String encoding;
+
+    private final List<ParquetColumnFormat> columns;
 
     /**
      * Creates a new instance with default settings.
@@ -40,6 +152,12 @@ public class ParquetFileFormat implements DumpFileFormat {
      */
     public ParquetFileFormat(@Nonnull Builder builder) {
         Objects.requireNonNull(builder);
+        this.parquetVersion = builder.parquetVersion;
+        this.recordBatchSize = builder.recordBatchSize;
+        this.recordBatchInBytes = builder.recordBatchInBytes;
+        this.codec = builder.codec;
+        this.encoding = builder.encoding;
+        this.columns = List.copyOf(builder.columns);
     }
 
     /**
@@ -55,14 +173,68 @@ public class ParquetFileFormat implements DumpFileFormat {
         return FormatType.PARQUET;
     }
 
+    /**
+     * Returns the parquet file format version.
+     * @return the parquet file format version, or {@code empty} if it is not defined
+     */
+    public Optional<String> getParquetVersion() {
+        return Optional.ofNullable(parquetVersion);
+    }
+
+    /**
+     * Returns the maximum number of rows in the same row group.
+     * @return the maximum number of rows in the same row group, or {@code empty} if it is not defined
+     */
+    public OptionalLong getRecordBatchSize() {
+        return wrap(recordBatchSize);
+    }
+
+    /**
+     * Returns the approximately maximum row group size in bytes.
+     * @return the max row group size from estimated record size, or {@code empty} if it is not defined
+     */
+    public OptionalLong getRecordBatchInBytes() {
+        return wrap(recordBatchInBytes);
+    }
+
+    /**
+     * Returns the common compression codec name of the individual columns.
+     * @return the common compression codec name of the individual columns, or {@code empty} if it is not defined
+     */
+    public Optional<String> getCodec() {
+        return Optional.ofNullable(codec);
+    }
+
+    /**
+     * Returns the common encoding type of the individual columns.
+     * @return the common encoding type of the individual columns, or {@code empty} if it is not defined
+     */
+    public Optional<String> getEncoding() {
+        return Optional.ofNullable(encoding);
+    }
+
+    /**
+     * Returns individual column settings.
+     * @return individual column settings
+     */
+    public List<ParquetColumnFormat> getColumns() {
+        return columns;
+    }
+
     @Override
     public SqlRequest.ParquetFileFormat toProtocolBuffer() {
+        // FIXME: impl
         return SqlRequest.ParquetFileFormat.getDefaultInstance();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(FormatType.PARQUET);
+        return Objects.hash(
+                getFormatType(),
+                parquetVersion,
+                recordBatchInBytes, recordBatchSize,
+                codec, encoding,
+                columns);
     }
 
     @Override
@@ -76,12 +248,28 @@ public class ParquetFileFormat implements DumpFileFormat {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        return true;
+        ParquetFileFormat other = (ParquetFileFormat) obj;
+        return Objects.equals(parquetVersion, other.parquetVersion)
+                && Objects.equals(recordBatchInBytes, other.recordBatchInBytes)
+                && Objects.equals(recordBatchSize, other.recordBatchSize)
+                && Objects.equals(codec, other.codec)
+                && Objects.equals(encoding, other.encoding)
+                && Objects.equals(columns, other.columns);
     }
 
     @Override
     public String toString() {
-        // FIXME: more fields
-        return "ParquetFileFormat()";
+        return String.format(
+                "ParquetFileFormat(parquetVersion=%s, recordBatchSize=%s, recordBatchInBytes=%s, " //$NON-NLS-1$
+                + "codec=%s, encoding=%s, columns=%s)", //$NON-NLS-1$
+                parquetVersion, recordBatchSize, recordBatchInBytes,
+                codec, encoding, columns);
+    }
+
+    private static OptionalLong wrap(@Nullable Long value) {
+        if (value == null) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(value);
     }
 }

--- a/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ParquetFileFormat.java
+++ b/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/ParquetFileFormat.java
@@ -223,8 +223,16 @@ public class ParquetFileFormat implements DumpFileFormat {
 
     @Override
     public SqlRequest.ParquetFileFormat toProtocolBuffer() {
-        // FIXME: impl
-        return SqlRequest.ParquetFileFormat.getDefaultInstance();
+        var builder = SqlRequest.ParquetFileFormat.newBuilder();
+        getParquetVersion().ifPresent(builder::setParquetVersion);
+        getRecordBatchSize().ifPresent(builder::setRecordBatchSize);
+        getRecordBatchInBytes().ifPresent(builder::setRecordBatchInBytes);
+        getCodec().ifPresent(builder::setCodec);
+        getEncoding().ifPresent(builder::setEncoding);
+        getColumns().stream()
+                .map(ParquetColumnFormat::toProtocolBuffer)
+                .forEachOrdered(builder::addColumns);
+        return builder.build();
     }
 
     @Override

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ArrowFileFormatTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ArrowFileFormatTest.java
@@ -43,6 +43,7 @@ class ArrowFileFormatTest {
 
         assertEquals(
                 SqlRequest.ArrowFileFormat.newBuilder()
+                    .setMetadataVersion("4")
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -57,6 +58,7 @@ class ArrowFileFormatTest {
 
         assertEquals(
                 SqlRequest.ArrowFileFormat.newBuilder()
+                    .setAlignment(16)
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -71,6 +73,7 @@ class ArrowFileFormatTest {
 
         assertEquals(
                 SqlRequest.ArrowFileFormat.newBuilder()
+                    .setRecordBatchSize(100)
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -85,6 +88,7 @@ class ArrowFileFormatTest {
 
         assertEquals(
                 SqlRequest.ArrowFileFormat.newBuilder()
+                    .setRecordBatchInBytes(10000)
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -99,6 +103,7 @@ class ArrowFileFormatTest {
 
         assertEquals(
                 SqlRequest.ArrowFileFormat.newBuilder()
+                    .setCodec("gzip")
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -113,6 +118,7 @@ class ArrowFileFormatTest {
 
         assertEquals(
                 SqlRequest.ArrowFileFormat.newBuilder()
+                    .setMinSpaceSaving(0.75)
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -127,24 +133,40 @@ class ArrowFileFormatTest {
 
         assertEquals(
                 SqlRequest.ArrowFileFormat.newBuilder()
+                    .setCharacterFieldType(SqlRequest.ArrowCharacterFieldType.FIXED_SIZE_BINARY)
                     .build(),
                 f.toProtocolBuffer());
     }
 
     @Test
-    void alignment_zero() {
+    void character_field_type_another() {
+        var f = ArrowFileFormat.newBuilder()
+                .withCharacterFieldType(ArrowFileFormat.CharacterFieldType.STRING)
+                .build();
+
+        assertEquals(Optional.of(ArrowFileFormat.CharacterFieldType.STRING), f.getCharacterFieldType());
+
+        assertEquals(
+                SqlRequest.ArrowFileFormat.newBuilder()
+                    .setCharacterFieldType(SqlRequest.ArrowCharacterFieldType.STRING)
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void alignment_under() {
         var b = ArrowFileFormat.newBuilder();
         assertThrows(IllegalArgumentException.class, () -> b.withAlignment(0));
     }
 
     @Test
-    void record_batch_size_zero() {
+    void record_batch_size_under() {
         var b = ArrowFileFormat.newBuilder();
         assertThrows(IllegalArgumentException.class, () -> b.withRecordBatchSize(0L));
     }
 
     @Test
-    void record_batch_in_bytes_zero() {
+    void record_batch_in_bytes_under() {
         var b = ArrowFileFormat.newBuilder();
         assertThrows(IllegalArgumentException.class, () -> b.withRecordBatchInBytes(0L));
     }

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ArrowFileFormatTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ArrowFileFormatTest.java
@@ -1,0 +1,163 @@
+package com.tsurugidb.tools.tgdump.core.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+
+import org.junit.jupiter.api.Test;
+
+import com.tsurugidb.sql.proto.SqlRequest;
+
+class ArrowFileFormatTest {
+
+    @Test
+    void defaults() {
+        var f = ArrowFileFormat.newBuilder()
+                .build();
+
+        assertEquals(DumpFileFormat.FormatType.ARROW, f.getFormatType());
+        assertEquals(Optional.empty(), f.getMetadataVersion());
+        assertEquals(OptionalInt.empty(), f.getAlignment());
+        assertEquals(OptionalLong.empty(), f.getRecordBatchSize());
+        assertEquals(OptionalLong.empty(), f.getRecordBatchInBytes());
+        assertEquals(Optional.empty(), f.getCodec());
+        assertEquals(OptionalDouble.empty(), f.getMinSpaceSaving());
+        assertEquals(Optional.empty(), f.getCharacterFieldType());
+
+        assertEquals(new ArrowFileFormat(), f, f.toString());
+
+        assertEquals(SqlRequest.ArrowFileFormat.getDefaultInstance(), f.toProtocolBuffer());
+    }
+
+    @Test
+    void metadata_version() {
+        var f = ArrowFileFormat.newBuilder()
+                .withMetadataVersion("4")
+                .build();
+
+        assertEquals(Optional.of("4"), f.getMetadataVersion());
+
+        assertEquals(
+                SqlRequest.ArrowFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void alignment() {
+        var f = ArrowFileFormat.newBuilder()
+                .withAlignment(16)
+                .build();
+
+        assertEquals(OptionalInt.of(16), f.getAlignment());
+
+        assertEquals(
+                SqlRequest.ArrowFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void record_batch_size() {
+        var f = ArrowFileFormat.newBuilder()
+                .withRecordBatchSize(100L)
+                .build();
+
+        assertEquals(OptionalLong.of(100), f.getRecordBatchSize());
+
+        assertEquals(
+                SqlRequest.ArrowFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void record_batch_in_bytes() {
+        var f = ArrowFileFormat.newBuilder()
+                .withRecordBatchInBytes(10000L)
+                .build();
+
+        assertEquals(OptionalLong.of(10000L), f.getRecordBatchInBytes());
+
+        assertEquals(
+                SqlRequest.ArrowFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void codec() {
+        var f = ArrowFileFormat.newBuilder()
+                .withCodec("gzip")
+                .build();
+
+        assertEquals(Optional.of("gzip"), f.getCodec());
+
+        assertEquals(
+                SqlRequest.ArrowFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void min_space_saving() {
+        var f = ArrowFileFormat.newBuilder()
+                .withMinSpaceSaving(0.75)
+                .build();
+
+        assertEquals(OptionalDouble.of(0.75), f.getMinSpaceSaving());
+
+        assertEquals(
+                SqlRequest.ArrowFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void character_field_type() {
+        var f = ArrowFileFormat.newBuilder()
+                .withCharacterFieldType(ArrowFileFormat.CharacterFieldType.FIXED_SIZE_BINARY)
+                .build();
+
+        assertEquals(Optional.of(ArrowFileFormat.CharacterFieldType.FIXED_SIZE_BINARY), f.getCharacterFieldType());
+
+        assertEquals(
+                SqlRequest.ArrowFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void alignment_zero() {
+        var b = ArrowFileFormat.newBuilder();
+        assertThrows(IllegalArgumentException.class, () -> b.withAlignment(0));
+    }
+
+    @Test
+    void record_batch_size_zero() {
+        var b = ArrowFileFormat.newBuilder();
+        assertThrows(IllegalArgumentException.class, () -> b.withRecordBatchSize(0L));
+    }
+
+    @Test
+    void record_batch_in_bytes_zero() {
+        var b = ArrowFileFormat.newBuilder();
+        assertThrows(IllegalArgumentException.class, () -> b.withRecordBatchInBytes(0L));
+    }
+
+    @Test
+    void min_space_saving_under() {
+        var b = ArrowFileFormat.newBuilder();
+        assertThrows(IllegalArgumentException.class, () -> b.withMinSpaceSaving(-0.01));
+    }
+
+    @Test
+    void min_space_saving_over() {
+        var b = ArrowFileFormat.newBuilder();
+        assertThrows(IllegalArgumentException.class, () -> b.withMinSpaceSaving(1.01));
+    }
+}

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/DumpProfileTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/DumpProfileTest.java
@@ -2,11 +2,60 @@ package com.tsurugidb.tools.tgdump.core.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Locale;
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 
 import com.tsurugidb.sql.proto.SqlRequest;
 
 class DumpProfileTest {
+
+    @Test
+    void defaults() {
+        var p = new DumpProfile();
+        assertEquals(Optional.empty(), p.getTitle());
+        assertEquals(Optional.empty(), p.getDescription());
+        assertEquals(Optional.empty(), p.getLocalizedDescription(Locale.ENGLISH));
+        assertEquals(Optional.empty(), p.getFileFormat());
+
+        assertEquals(p, DumpProfile.newBuilder().build(), p.toString());
+    }
+
+    @Test
+    void title() {
+        var p = DumpProfile.newBuilder()
+                .withTitle("testing")
+                .build();
+        assertEquals(Optional.of("testing"), p.getTitle());
+    }
+
+    @Test
+    void description() {
+        var p = DumpProfile.newBuilder()
+                .withDescription("testing")
+                .build();
+        assertEquals(Optional.of("testing"), p.getDescription());
+    }
+
+    @Test
+    void localized_description() {
+        var p = DumpProfile.newBuilder()
+                .withLocalizedDescription("en", "English")
+                .withLocalizedDescription("ja", "Japanese")
+                .build();
+        assertEquals(Optional.of("English"), p.getLocalizedDescription(Locale.ENGLISH));
+        assertEquals(Optional.of("Japanese"), p.getLocalizedDescription(Locale.JAPANESE));
+        assertEquals(Optional.empty(), p.getLocalizedDescription(Locale.CHINESE));
+    }
+
+    @Test
+    void file_foramat() {
+        var p = DumpProfile.newBuilder()
+                .withFileFormat(new ParquetFileFormat())
+                .build();
+        assertEquals(Optional.of(new ParquetFileFormat()), p.getFileFormat());
+    }
 
     @Test
     void toProtocolBuffer_default() {

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ParquetColumnFormatTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ParquetColumnFormatTest.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import com.tsurugidb.sql.proto.SqlRequest;
+
 class ParquetColumnFormatTest {
 
     @Test
@@ -17,6 +19,12 @@ class ParquetColumnFormatTest {
         assertEquals(Optional.empty(), f.getEncoding());
 
         assertEquals(f, ParquetColumnFormat.newBuilder("testing").build(), f.toString());
+
+        assertEquals(
+                SqlRequest.ParquetColumnFormat.newBuilder()
+                    .setName("testing")
+                    .build(),
+                f.toProtocolBuffer());
     }
 
     @Test
@@ -26,6 +34,13 @@ class ParquetColumnFormatTest {
                 .build();
 
         assertEquals(Optional.of("snappy"), f.getCodec());
+
+        assertEquals(
+                SqlRequest.ParquetColumnFormat.newBuilder()
+                    .setName("testing")
+                    .setCodec("snappy")
+                    .build(),
+                f.toProtocolBuffer());
     }
 
     @Test
@@ -35,5 +50,12 @@ class ParquetColumnFormatTest {
                 .build();
 
         assertEquals(Optional.of("RLE"), f.getEncoding());
+
+        assertEquals(
+                SqlRequest.ParquetColumnFormat.newBuilder()
+                    .setName("testing")
+                    .setEncoding("RLE")
+                    .build(),
+                f.toProtocolBuffer());
     }
 }

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ParquetColumnFormatTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ParquetColumnFormatTest.java
@@ -1,0 +1,39 @@
+package com.tsurugidb.tools.tgdump.core.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+class ParquetColumnFormatTest {
+
+    @Test
+    void simple() {
+        var f = new ParquetColumnFormat("testing");
+
+        assertEquals("testing", f.getName());
+        assertEquals(Optional.empty(), f.getCodec());
+        assertEquals(Optional.empty(), f.getEncoding());
+
+        assertEquals(f, ParquetColumnFormat.newBuilder("testing").build(), f.toString());
+    }
+
+    @Test
+    void codec() {
+        var f = ParquetColumnFormat.forColumn(("testing"))
+                .withCodec("snappy")
+                .build();
+
+        assertEquals(Optional.of("snappy"), f.getCodec());
+    }
+
+    @Test
+    void encoding() {
+        var f = ParquetColumnFormat.forColumn(("testing"))
+                .withEncoding("RLE")
+                .build();
+
+        assertEquals(Optional.of("RLE"), f.getEncoding());
+    }
+}

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ParquetFileFormatTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ParquetFileFormatTest.java
@@ -1,0 +1,151 @@
+package com.tsurugidb.tools.tgdump.core.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import org.junit.jupiter.api.Test;
+
+import com.tsurugidb.sql.proto.SqlRequest;
+
+class ParquetFileFormatTest {
+
+    @Test
+    void defaults() {
+        var f = new ParquetFileFormat();
+
+        assertEquals(DumpFileFormat.FormatType.PARQUET, f.getFormatType());
+        assertEquals(Optional.empty(), f.getParquetVersion());
+        assertEquals(OptionalLong.empty(), f.getRecordBatchSize());
+        assertEquals(OptionalLong.empty(), f.getRecordBatchInBytes());
+        assertEquals(Optional.empty(), f.getCodec());
+        assertEquals(Optional.empty(), f.getEncoding());
+        assertEquals(List.of(), f.getColumns());
+
+        assertEquals(f, ParquetFileFormat.newBuilder().build(), f.toString());
+
+        assertEquals(SqlRequest.ParquetFileFormat.getDefaultInstance(), f.toProtocolBuffer());
+    }
+
+    @Test
+    void parquet_version() {
+        var f = ParquetFileFormat.newBuilder()
+                .withParquetVersion("2.5")
+                .build();
+
+        assertEquals(Optional.of("2.5"), f.getParquetVersion());
+
+        assertEquals(
+                SqlRequest.ParquetFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void record_batch_size() {
+        var f = ParquetFileFormat.newBuilder()
+                .withRecordBatchSize(100L)
+                .build();
+
+        assertEquals(OptionalLong.of(100), f.getRecordBatchSize());
+
+        assertEquals(
+                SqlRequest.ParquetFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void record_batch_in_bytes() {
+        var f = ParquetFileFormat.newBuilder()
+                .withRecordBatchInBytes(10000L)
+                .build();
+
+        assertEquals(OptionalLong.of(10000), f.getRecordBatchInBytes());
+
+        assertEquals(
+                SqlRequest.ParquetFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void codec() {
+        var f = ParquetFileFormat.newBuilder()
+                .withCodec("gzip")
+                .build();
+
+        assertEquals(Optional.of("gzip"), f.getCodec());
+
+        assertEquals(
+                SqlRequest.ParquetFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void encoding() {
+        var f = ParquetFileFormat.newBuilder()
+                .withEncoding("plain")
+                .build();
+
+        assertEquals(Optional.of("plain"), f.getEncoding());
+
+        assertEquals(
+                SqlRequest.ParquetFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void columns() {
+        var f = ParquetFileFormat.newBuilder()
+                .withColumns(List.of(
+                        new ParquetColumnFormat("testing")))
+                .build();
+
+        assertEquals(List.of(new ParquetColumnFormat("testing")), f.getColumns());
+
+        assertEquals(
+                SqlRequest.ParquetFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void columns_multiple() {
+        var f = ParquetFileFormat.newBuilder()
+                .withColumns(List.of(
+                        new ParquetColumnFormat("a"),
+                        new ParquetColumnFormat("b"),
+                        new ParquetColumnFormat("c")))
+                .build();
+
+        assertEquals(
+                List.of(
+                        new ParquetColumnFormat("a"),
+                        new ParquetColumnFormat("b"),
+                        new ParquetColumnFormat("c")),
+                f.getColumns());
+
+        assertEquals(
+                SqlRequest.ParquetFileFormat.newBuilder()
+                    .build(),
+                f.toProtocolBuffer());
+    }
+
+    @Test
+    void record_batch_size_zero() {
+        var b = ParquetFileFormat.newBuilder();
+        assertThrows(IllegalArgumentException.class, () -> b.withRecordBatchSize(0L));
+    }
+
+    @Test
+    void record_batch_in_bytes_zero() {
+        var b = ParquetFileFormat.newBuilder();
+        assertThrows(IllegalArgumentException.class, () -> b.withRecordBatchInBytes(0L));
+    }
+}

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ParquetFileFormatTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/ParquetFileFormatTest.java
@@ -40,6 +40,7 @@ class ParquetFileFormatTest {
 
         assertEquals(
                 SqlRequest.ParquetFileFormat.newBuilder()
+                    .setParquetVersion("2.5")
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -54,6 +55,7 @@ class ParquetFileFormatTest {
 
         assertEquals(
                 SqlRequest.ParquetFileFormat.newBuilder()
+                    .setRecordBatchSize(100)
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -68,6 +70,7 @@ class ParquetFileFormatTest {
 
         assertEquals(
                 SqlRequest.ParquetFileFormat.newBuilder()
+                    .setRecordBatchInBytes(10000)
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -82,6 +85,7 @@ class ParquetFileFormatTest {
 
         assertEquals(
                 SqlRequest.ParquetFileFormat.newBuilder()
+                    .setCodec("gzip")
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -96,6 +100,7 @@ class ParquetFileFormatTest {
 
         assertEquals(
                 SqlRequest.ParquetFileFormat.newBuilder()
+                    .setEncoding("plain")
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -111,6 +116,9 @@ class ParquetFileFormatTest {
 
         assertEquals(
                 SqlRequest.ParquetFileFormat.newBuilder()
+                    .addColumns(SqlRequest.ParquetColumnFormat.newBuilder()
+                            .setName("testing")
+                            .build())
                     .build(),
                 f.toProtocolBuffer());
     }
@@ -133,18 +141,27 @@ class ParquetFileFormatTest {
 
         assertEquals(
                 SqlRequest.ParquetFileFormat.newBuilder()
-                    .build(),
+                    .addColumns(SqlRequest.ParquetColumnFormat.newBuilder()
+                            .setName("a")
+                            .build())
+                    .addColumns(SqlRequest.ParquetColumnFormat.newBuilder()
+                            .setName("b")
+                            .build())
+                    .addColumns(SqlRequest.ParquetColumnFormat.newBuilder()
+                            .setName("c")
+                            .build())
+                   .build(),
                 f.toProtocolBuffer());
     }
 
     @Test
-    void record_batch_size_zero() {
+    void record_batch_size_under() {
         var b = ParquetFileFormat.newBuilder();
         assertThrows(IllegalArgumentException.class, () -> b.withRecordBatchSize(0L));
     }
 
     @Test
-    void record_batch_in_bytes_zero() {
+    void record_batch_in_bytes_under() {
         var b = ParquetFileFormat.newBuilder();
         assertThrows(IllegalArgumentException.class, () -> b.withRecordBatchInBytes(0L));
     }

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/TransactionSettingsTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/TransactionSettingsTest.java
@@ -13,10 +13,18 @@ class TransactionSettingsTest {
 
     @Test
     void defaults() {
-        var s = new TransactionSettings();
+        var s = TransactionSettings.newBuilder()
+                .build();
         assertEquals(TransactionSettings.DEFAULT_TYPE, s.getType());
         assertEquals(Optional.empty(), s.getLabel());
         assertEquals(TransactionSettings.DEFAULT_ENABLE_READ_AREAS, s.isEnableReadAreas());
+
+        assertEquals(s, new TransactionSettings(), s.toString());
+        assertEquals(
+                SqlRequest.TransactionOption.newBuilder()
+                        .setType(SqlRequest.TransactionType.READ_ONLY)
+                        .build(),
+                s.toProtocolBuffer(List.of()));
     }
 
     @Test

--- a/modules/tgdump/profile/src/main/java/com/tsurugidb/tools/tgdump/profile/DumpProfileReader.java
+++ b/modules/tgdump/profile/src/main/java/com/tsurugidb/tools/tgdump/profile/DumpProfileReader.java
@@ -6,13 +6,18 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -29,6 +34,7 @@ import com.tsurugidb.tools.common.diagnostic.DiagnosticUtil;
 import com.tsurugidb.tools.tgdump.core.model.ArrowFileFormat;
 import com.tsurugidb.tools.tgdump.core.model.DumpFileFormat;
 import com.tsurugidb.tools.tgdump.core.model.DumpProfile;
+import com.tsurugidb.tools.tgdump.core.model.ParquetColumnFormat;
 import com.tsurugidb.tools.tgdump.core.model.ParquetFileFormat;
 
 /**
@@ -48,38 +54,117 @@ public class DumpProfileReader {
 
     /**
      * The JSON field name of the file format version.
+     * @see DumpProfile#getTitle()
      */
     public static final String FIELD_TITLE = "title"; //$NON-NLS-1$
 
     /**
      * The JSON field name of the file format version.
+     * @see DumpProfile#getDescription()
      */
     public static final String FIELD_DESCRIPTION = "description"; //$NON-NLS-1$
 
     /**
      * The JSON field name of the file format version.
+     * @see DumpProfile#getLocalizedDescription(Locale)
      */
     public static final String FIELD_PREFIX_LOCALIZED_DESCRIPTION = "description."; //$NON-NLS-1$
 
     /**
      * The JSON field name of the file format version.
+     * @see DumpProfile#getFileFormat()
      */
     public static final String FIELD_FILE_FORMAT = "file_format"; //$NON-NLS-1$
 
     /**
      * The JSON field name of the file format type name.
+     * @see DumpFileFormat#getFormatType()
      */
     public static final String FIELD_FORMAT_TYPE = "format_type"; //$NON-NLS-1$
 
     /**
      * The dump file format name of Apache Parquet.
+     * @see com.tsurugidb.tools.tgdump.core.model.DumpFileFormat.FormatType#PARQUET
      */
     public static final String FORMAT_TYPE_PARQUET = "parquet"; //$NON-NLS-1$
 
     /**
      * The dump file format name of Apache Arrow.
+     * @see com.tsurugidb.tools.tgdump.core.model.DumpFileFormat.FormatType#ARROW
      */
     public static final String FORMAT_TYPE_ARROW = "arrow"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of Parquet version.
+     * @see ParquetFileFormat#getParquetVersion()
+     */
+    public static final String FIELD_PARQUET_VERSION = "parquet_version"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of record batch size.
+     * @see ParquetFileFormat#getRecordBatchSize()
+     * @see ArrowFileFormat#getRecordBatchSize()
+     */
+    public static final String FIELD_RECORD_BATCH_SIZE = "record_batch_size"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of record batch size from estimated record size.
+     * @see ParquetFileFormat#getRecordBatchInBytes()
+     * @see ArrowFileFormat#getRecordBatchInBytes()
+     */
+    public static final String FIELD_RECORD_BATCH_IN_BYTES = "record_batch_in_bytes"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of compression codec.
+     * @see ParquetFileFormat#getCodec()
+     * @see ParquetColumnFormat#getCodec()
+     * @see ArrowFileFormat#getCodec()
+     */
+    public static final String FIELD_CODEC = "codec"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of column encoding.
+     * @see ParquetFileFormat#getEncoding()
+     * @see ParquetColumnFormat#getEncoding()
+     */
+    public static final String FIELD_ENCODING = "encoding"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of column specific settings.
+     * @see ParquetFileFormat#getColumns()
+     */
+    public static final String FIELD_COLUMNS = "columns"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of metadata version.
+     * @see ArrowFileFormat#getMetadataVersion()
+     */
+    public static final String FIELD_METADATA_VERSION = "metadata_version"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of byte alignment.
+     * @see ArrowFileFormat#getAlignment()
+     */
+    public static final String FIELD_ALIGNMENT = "alignment"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of threshold for adopting compressed data.
+     * @see ArrowFileFormat#getMinSpaceSaving()
+     */
+    public static final String FIELD_MIN_SPACE_SAVING = "min_space_saving"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of {@code CHAR} field type in Apache Arrow format.
+     * @see ArrowFileFormat#getCharacterFieldType()
+     * @see com.tsurugidb.tools.tgdump.core.model.ArrowFileFormat.CharacterFieldType
+     */
+    public static final String FIELD_CHARACTER_FIELD_TYPE = "character_field_type"; //$NON-NLS-1$
+
+    /**
+     * The JSON field name of target column name.
+     * @see ParquetColumnFormat#getName()
+     */
+    public static final String FIELD_NAME = "name"; //$NON-NLS-1$
 
     static final Logger LOG = LoggerFactory.getLogger(DumpProfileReader.class);
 
@@ -264,7 +349,80 @@ public class DumpProfileReader {
         consumed.add(FIELD_FORMAT_TYPE); // already consumed
         var result = ParquetFileFormat.newBuilder();
 
-        // more fields
+        findString(consumed, node, FIELD_PARQUET_VERSION)
+            .filter(it -> !it.isBlank())
+            .ifPresent(result::withParquetVersion);
+
+        checkPositiveLong(
+                findNode(consumed, node, FIELD_RECORD_BATCH_SIZE),
+                location, prefix + FIELD_RECORD_BATCH_SIZE)
+                .ifPresent(result::withRecordBatchSize);
+
+        checkPositiveLong(
+                findNode(consumed, node, FIELD_RECORD_BATCH_IN_BYTES),
+                location, prefix + FIELD_RECORD_BATCH_IN_BYTES)
+                .ifPresent(result::withRecordBatchInBytes);
+
+        findString(consumed, node, FIELD_CODEC)
+            .filter(it -> !it.isBlank())
+            .ifPresent(result::withCodec);
+
+        findString(consumed, node, FIELD_ENCODING)
+            .filter(it -> !it.isBlank())
+            .ifPresent(result::withEncoding);
+
+        var columns = findNode(consumed, node, FIELD_COLUMNS);
+        if (columns.isPresent()) {
+            if (!columns.get().isArray()) {
+                throw new ProfileException(
+                        ProfileDiagnosticCode.PROFILE_INVALID,
+                        List.of(location, MessageFormat.format(
+                                "value must be an array of objects: {0}",
+                                prefix + FIELD_COLUMNS)));
+            }
+            var columnList = new ArrayList<ParquetColumnFormat>(columns.get().size());
+            for (var element : columns.get()) {
+                if (!element.isObject()) {
+                    throw new ProfileException(
+                            ProfileDiagnosticCode.PROFILE_INVALID,
+                            List.of(location, MessageFormat.format(
+                                    "value must be an object: {0}[{1}]",
+                                    prefix + FIELD_COLUMNS,
+                                    columnList.size())));
+                }
+                var r = convertParquetColumnFormat(location, columnList.size(), element);
+                columnList.add(r);
+            }
+            result.withColumns(columnList);
+        }
+
+        checkExtraFields(location, node, prefix, consumed);
+        return result.build();
+    }
+
+    private static ParquetColumnFormat convertParquetColumnFormat(String location, int index, JsonNode node)
+            throws DiagnosticException {
+        var prefix = String.format("%s.%s[%d].", FIELD_FILE_FORMAT, FIELD_COLUMNS, index); //$NON-NLS-1$
+        var consumed = new HashSet<String>();
+
+        var name = findString(consumed, node, FIELD_NAME)
+                .filter(it -> !it.isBlank())
+                .map(it -> it.toLowerCase(Locale.ENGLISH))
+                .orElseThrow(() -> new ProfileException(
+                        ProfileDiagnosticCode.PROFILE_INVALID,
+                        List.of(location, MessageFormat.format(
+                                "target column name must be set: {0}",
+                                prefix + FIELD_NAME))));
+
+        var result = ParquetColumnFormat.forColumn(name);
+
+        findString(consumed, node, FIELD_CODEC)
+            .filter(it -> !it.isBlank())
+            .ifPresent(result::withCodec);
+
+        findString(consumed, node, FIELD_ENCODING)
+            .filter(it -> !it.isBlank())
+            .ifPresent(result::withEncoding);
 
         checkExtraFields(location, node, prefix, consumed);
         return result.build();
@@ -277,7 +435,40 @@ public class DumpProfileReader {
         consumed.add(FIELD_FORMAT_TYPE); // already consumed
         var result = ArrowFileFormat.newBuilder();
 
-        // more fields
+
+        findString(consumed, node, FIELD_METADATA_VERSION)
+            .filter(it -> !it.isBlank())
+            .ifPresent(result::withMetadataVersion);
+
+        checkPositiveInt(
+                findNode(consumed, node, FIELD_ALIGNMENT),
+                location, prefix + FIELD_ALIGNMENT)
+                .ifPresent(result::withAlignment);
+
+        checkPositiveLong(
+                findNode(consumed, node, FIELD_RECORD_BATCH_SIZE),
+                location, prefix + FIELD_RECORD_BATCH_SIZE)
+                .ifPresent(result::withRecordBatchSize);
+
+        checkPositiveLong(
+                findNode(consumed, node, FIELD_RECORD_BATCH_IN_BYTES),
+                location, prefix + FIELD_RECORD_BATCH_IN_BYTES)
+                .ifPresent(result::withRecordBatchInBytes);
+
+        findString(consumed, node, FIELD_CODEC)
+            .filter(it -> !it.isBlank())
+            .ifPresent(result::withCodec);
+
+        checkNomarizedRatio(
+                findNode(consumed, node, FIELD_MIN_SPACE_SAVING),
+                location, prefix + FIELD_MIN_SPACE_SAVING)
+                .ifPresent(result::withMinSpaceSaving);
+
+        checkEnum(
+                findNode(consumed, node, FIELD_CHARACTER_FIELD_TYPE),
+                ArrowFileFormat.CharacterFieldType.class,
+                location, prefix + FIELD_CHARACTER_FIELD_TYPE)
+                .ifPresent(result::withCharacterFieldType);
 
         checkExtraFields(location, node, prefix, consumed);
         return result.build();
@@ -296,6 +487,111 @@ public class DumpProfileReader {
             consumed.add(fieldName);
         }
         return findNode(consumed, node, fieldName).map(JsonNode::asText);
+    }
+
+    private static OptionalInt checkPositiveInt(
+            Optional<JsonNode> node, String location, String path) throws ProfileException {
+        if (node.isEmpty()) {
+            return OptionalInt.empty();
+        }
+        var n = node.get();
+        if (!n.canConvertToInt()) {
+            throw new ProfileException(
+                    ProfileDiagnosticCode.PROFILE_INVALID,
+                    List.of(location, MessageFormat.format(
+                            "value must be an int value: {0} ({1})",
+                            path,
+                            n.asText())));
+        }
+        var value = n.asInt();
+        if (value < 1) {
+            throw new ProfileException(
+                    ProfileDiagnosticCode.PROFILE_INVALID,
+                    List.of(location, MessageFormat.format(
+                            "value must be greater than 0: {0} ({1})",
+                            path,
+                            value)));
+        }
+        return OptionalInt.of(value);
+    }
+
+    private static OptionalLong checkPositiveLong(
+            Optional<JsonNode> node, String location, String path) throws ProfileException {
+        if (node.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        var n = node.get();
+        if (!n.canConvertToLong()) {
+            throw new ProfileException(
+                    ProfileDiagnosticCode.PROFILE_INVALID,
+                    List.of(location, MessageFormat.format(
+                            "value must be a long value: {0} ({1})",
+                            path,
+                            n.asText())));
+        }
+        var value = n.asLong();
+        if (value < 1) {
+            throw new ProfileException(
+                    ProfileDiagnosticCode.PROFILE_INVALID,
+                    List.of(location, MessageFormat.format(
+                            "value must be greater than 0: {0} ({1})",
+                            path,
+                            value)));
+        }
+        return OptionalLong.of(value);
+    }
+
+    private static OptionalDouble checkNomarizedRatio(
+            Optional<JsonNode> node, String location, String path) throws ProfileException {
+        if (node.isEmpty()) {
+            return OptionalDouble.empty();
+        }
+        var n = node.get();
+        if (!n.isNumber()) {
+            throw new ProfileException(
+                    ProfileDiagnosticCode.PROFILE_INVALID,
+                    List.of(location, MessageFormat.format(
+                            "value must be a numeric value: {0} ({1})",
+                            path,
+                            n.asText())));
+        }
+        var value = n.asDouble();
+        if (value < 0.0 || value > 1.0) {
+            throw new ProfileException(
+                    ProfileDiagnosticCode.PROFILE_INVALID,
+                    List.of(location, MessageFormat.format(
+                            "value must be in [0.0, 1.0]: {0} ({1})",
+                            path,
+                            value)));
+        }
+        return OptionalDouble.of(value);
+    }
+
+    private static <E extends Enum<E>> Optional<E> checkEnum(
+            Optional<JsonNode> node, Class<E> enumType, String location, String path) throws ProfileException {
+        var name = node.map(JsonNode::asText)
+                .map(String::strip)
+                .filter(it -> !it.isEmpty())
+                .map(it -> it.toUpperCase(Locale.ENGLISH))
+                .orElse(null);
+        if (name == null) {
+            return Optional.empty();
+        }
+        try {
+            var constant = Enum.valueOf(enumType, name);
+            return Optional.of(constant);
+        } catch (IllegalArgumentException e) {
+            LOG.debug("cannot find enum constant: {}#{}", enumType.getName(), name, e); //$NON-NLS-1$
+            throw new ProfileException(
+                    ProfileDiagnosticCode.PROFILE_INVALID,
+                    List.of(location, MessageFormat.format(
+                            "unrecognized value \"{1}\" in {0}, must be one of {2}",
+                            path,
+                            name,
+                            Arrays.stream(enumType.getEnumConstants())
+                                    .map(Enum::name)
+                                    .collect(Collectors.joining(", ", "{", "}"))))); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+        }
     }
 
     private static void checkExtraFields(String location, JsonNode node, String prefix, Set<String> consumed)

--- a/modules/tgdump/profile/src/main/resources/META-INF/tsurugidb/tgdump/dump-profile.properties
+++ b/modules/tgdump/profile/src/main/resources/META-INF/tsurugidb/tgdump/dump-profile.properties
@@ -1,4 +1,5 @@
 # default dump profile
 default=META-INF/tsurugidb/tgdump/profiles/default.json
-parquet=META-INF/tsurugidb/tgdump/profiles/parquet.json
-arrow=META-INF/tsurugidb/tgdump/profiles/arrow.json
+Parquet=META-INF/tsurugidb/tgdump/profiles/parquet.json
+Arrow=META-INF/tsurugidb/tgdump/profiles/arrow.json
+PG-Strom=META-INF/tsurugidb/tgdump/profiles/pg-strom.json

--- a/modules/tgdump/profile/src/main/resources/META-INF/tsurugidb/tgdump/profiles/arrow.json
+++ b/modules/tgdump/profile/src/main/resources/META-INF/tsurugidb/tgdump/profiles/arrow.json
@@ -1,7 +1,7 @@
 // dump profile for generic Apache Arrow files.
 {
     "format_version": 1,
-    "title": "arrow",
+    "title": "Arrow",
     "description": "dump tables as Apache Arrow files.",
 
     // use the arrow file format type.

--- a/modules/tgdump/profile/src/main/resources/META-INF/tsurugidb/tgdump/profiles/parquet.json
+++ b/modules/tgdump/profile/src/main/resources/META-INF/tsurugidb/tgdump/profiles/parquet.json
@@ -1,7 +1,7 @@
 // dump profile for generic Apache Arrow files.
 {
     "format_version": 1,
-    "title": "parquet",
+    "title": "Parquet",
     "description": "dump tables as Apache Parquet files.",
 
     // use the arrow file format type.

--- a/modules/tgdump/profile/src/main/resources/META-INF/tsurugidb/tgdump/profiles/pg-strom.json
+++ b/modules/tgdump/profile/src/main/resources/META-INF/tsurugidb/tgdump/profiles/pg-strom.json
@@ -1,0 +1,12 @@
+// dump profile for PG-Strom.
+{
+    "format_version": 1,
+    "title": "PG-Strom",
+    "description": "dump tables as Apache Arrow files optimized for PG-Strom.",
+
+    "file_format": {
+        "format_type": "arrow",
+        "record_batch_in_bytes": 268435456, // 256MB
+        "character_field_type": "fixed_size_binary",
+    },
+}

--- a/modules/tgdump/profile/src/test/java/com/tsurugidb/tools/tgdump/profile/DumpProfileReaderTest.java
+++ b/modules/tgdump/profile/src/test/java/com/tsurugidb/tools/tgdump/profile/DumpProfileReaderTest.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.tsurugidb.tools.common.diagnostic.DiagnosticException;
 import com.tsurugidb.tools.tgdump.core.model.ArrowFileFormat;
 import com.tsurugidb.tools.tgdump.core.model.DumpProfile;
+import com.tsurugidb.tools.tgdump.core.model.ParquetColumnFormat;
 import com.tsurugidb.tools.tgdump.core.model.ParquetFileFormat;
 
 class DumpProfileReaderTest {
@@ -116,6 +117,244 @@ class DumpProfileReaderTest {
     }
 
     @Test
+    void file_format_parquet_parquet_version() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'parquet_version': '2.5',",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withParquetVersion("2.5")
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_record_batch_size() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'record_batch_size': 100,",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withRecordBatchSize(100L)
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_record_batch_in_bytes() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'record_batch_in_bytes': 10000,",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withRecordBatchInBytes(10000L)
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_codec() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'codec': 'snappy',",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withCodec("snappy")
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_encoding() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'encoding': 'plain',",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withEncoding("plain")
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_columns() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': [",
+                "       {",
+                "         'name': 'testing',",
+                "       }",
+                "     ],",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withColumns(List.of(
+                                    ParquetColumnFormat.newBuilder("testing")
+                                        .build()))
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_columns_multiple() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': [",
+                "       {",
+                "         'name': 'a',",
+                "       },",
+                "       {",
+                "         'name': 'b',",
+                "       },",
+                "       {",
+                "         'name': 'c',",
+                "       },",
+                "     ],",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withColumns(List.of(
+                                    ParquetColumnFormat.newBuilder("a")
+                                        .build(),
+                                    ParquetColumnFormat.newBuilder("b")
+                                        .build(),
+                                    ParquetColumnFormat.newBuilder("c")
+                                        .build()))
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_columns_empty() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': [],",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withColumns(List.of())
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_columns_codec() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': [",
+                "       {",
+                "         'name': 'testing',",
+                "         'codec': 'gzip',",
+                "       }",
+                "     ],",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withColumns(List.of(
+                                    ParquetColumnFormat.newBuilder("testing")
+                                        .withCodec("gzip")
+                                        .build()))
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_parquet_columns_encoding() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': [",
+                "       {",
+                "         'name': 'testing',",
+                "         'encoding': 'plain',",
+                "       }",
+                "     ],",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ParquetFileFormat.newBuilder()
+                            .withColumns(List.of(
+                                    ParquetColumnFormat.newBuilder("testing")
+                                        .withEncoding("plain")
+                                        .build()))
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
     void file_format_arrow() throws Exception {
         var profile = reader.readFromFile(prepare(new String[] {
                 "{",
@@ -128,6 +367,166 @@ class DumpProfileReaderTest {
         assertEquals(
                 DumpProfile.newBuilder()
                     .withFileFormat(ArrowFileFormat.newBuilder()
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_arrow_metadata_version() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'metadata_version': 4,",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ArrowFileFormat.newBuilder()
+                            .withMetadataVersion("4")
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_arrow_alignment() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'alignment': 16,",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ArrowFileFormat.newBuilder()
+                            .withAlignment(16)
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_arrow_record_batch_size() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'record_batch_size': 100,",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ArrowFileFormat.newBuilder()
+                            .withRecordBatchSize(100L)
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_arrow_record_batch_in_bytes() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'record_batch_in_bytes': 10000,",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ArrowFileFormat.newBuilder()
+                            .withRecordBatchInBytes(10000L)
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_arrow_codec() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'codec': 'lz4',",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ArrowFileFormat.newBuilder()
+                            .withCodec("lz4")
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_arrow_min_space_saving() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'min_space_saving': 0.95,",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ArrowFileFormat.newBuilder()
+                            .withMinSpaceSaving(0.95)
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_arrow_min_space_saving_int() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'min_space_saving': 1,",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ArrowFileFormat.newBuilder()
+                            .withMinSpaceSaving(1d)
+                            .build())
+                    .build(),
+                profile);
+    }
+
+    @Test
+    void file_format_arrow_character_field_type() throws Exception {
+        var profile = reader.readFromFile(prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'character_field_type': 'STRING',",
+                "  },",
+                "}",
+        }));
+        assertEquals(
+                DumpProfile.newBuilder()
+                    .withFileFormat(ArrowFileFormat.newBuilder()
+                            .withCharacterFieldType(ArrowFileFormat.CharacterFieldType.STRING)
                             .build())
                     .build(),
                 profile);
@@ -232,6 +631,96 @@ class DumpProfileReaderTest {
     }
 
     @Test
+    void parquet_record_batch_size_not_long() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'record_batch_size': 'NG',",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void parquet_record_batch_size_zero() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'record_batch_size': 0,",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void parquet_record_batch_in_bytes_zero() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'record_batch_in_bytes': 0,",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void parquet_columns_not_array() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': {},",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void parquet_columns_not_array_of_objects() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': [1],",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void parquet_columns_name_missing() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': [{}],",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
     void unknown_fields_in_parquet() throws Exception {
         var file = prepare(new String[] {
                 "{",
@@ -239,6 +728,159 @@ class DumpProfileReaderTest {
                 "  'file_format': {",
                 "    'format_type': 'parquet',",
                 "    'unknown': 1,",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void unknown_fields_in_parquet_columns() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'parquet',",
+                "    'columns': [{",
+                "      'name': 'testing',",
+                "      'unknown': 1,",
+                "     }],",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_alignment_not_long() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'alignment': 'NG',",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_alignment_zero() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'alignment': 0,",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_record_batch_size_not_long() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'record_batch_size': 'NG',",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_record_batch_size_zero() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'record_batch_size': 0,",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_record_batch_in_bytes_zero() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'record_batch_in_bytes': 0,",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_min_space_saving_not_numeric() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'min_space_saving': 'NG',",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_min_space_saving_under_zero() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'min_space_saving': -0.01,",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_min_space_saving_over_one() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'min_space_saving': 1.01,",
+                "  },",
+                "}",
+        });
+        var e = assertThrows(DiagnosticException.class, () -> reader.readFromFile(file));
+        assertEquals(ProfileDiagnosticCode.PROFILE_INVALID, e.getDiagnosticCode());
+    }
+
+    @Test
+    void arrow_character_field_type_unknown() throws Exception {
+        var file = prepare(new String[] {
+                "{",
+                "  'format_version': {format_version},",
+                "  'file_format': {",
+                "    'format_type': 'arrow',",
+                "    'character_field_type': 'UNKNOWN',",
                 "  },",
                 "}",
         });


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is work in progress.

This PR introduces `--profile PG-Strom` option to `tgdump` command.
It generates table dump as Apache Arrow files optimized for [PG-Strom](https://www.heterodb.com/).

Tasks:

* [x] Enhance dump profile models
* [x] Make dump profile reader accept the enhanced models
* [x] Support new protocol buffer fields
* [x] Add `PG-Strom` profile