### PR TITLE
build: fix distribution archive name.

### DIFF
--- a/buildSrc/src/main/groovy/tanzawa.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/tanzawa.java-conventions.gradle
@@ -108,3 +108,8 @@ task writeVersion(type: WriteProperties) {
 
 sourceSets.main.output.dir("${project.buildDir}/generated/version")
 processResources.dependsOn writeVersion
+
+tasks.withType(Tar) { task ->
+    task.archiveExtension = 'tar.gz'
+    task.compression = Compression.GZIP
+}

--- a/modules/tgdump/cli/build.gradle
+++ b/modules/tgdump/cli/build.gradle
@@ -23,6 +23,16 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
 }
 
+distributions {
+    main {
+        distributionBaseName = 'tgdump'
+    }
+    shadow {
+        distributionBaseName = 'tgdump'
+        distributionClassifier = 'shadow'
+    }
+}
+
 application {
     applicationName = 'tgdump'
     mainClass = 'com.tsurugidb.tools.tgdump.cli.Main'
@@ -37,16 +47,6 @@ shadowJar {
     archiveBaseName = 'tgdump'
     archiveClassifier = 'all'
     mergeServiceFiles()
-}
-
-distZip {
-    archiveFileName = "tgdump.zip"
-}
-
-distTar {
-    archiveFileName = "tgdump.tar.gz"
-    archiveExtension = 'tar.gz'
-    compression = Compression.GZIP
 }
 
 test {

--- a/modules/tgsql/cli/build.gradle
+++ b/modules/tgsql/cli/build.gradle
@@ -23,6 +23,16 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 }
 
+distributions {
+    main {
+        distributionBaseName = 'tgsql'
+    }
+    shadow {
+        distributionBaseName = 'tgsql'
+        distributionClassifier = 'shadow'
+    }
+}
+
 application {
     applicationName = 'tgsql'
     mainClass = 'com.tsurugidb.console.cli.Main'
@@ -39,14 +49,4 @@ shadowJar {
     archiveBaseName = 'tgsql'
     archiveClassifier = 'all'
     mergeServiceFiles()
-}
-
-distZip {
-    archiveFileName = "tgsql.zip"
-}
-
-distTar {
-    archiveFileName = "tgsql.tar.gz"
-    archiveExtension = 'tar.gz'
-    compression = Compression.GZIP
 }


### PR DESCRIPTION
* Makes all `Tar` type tasks generate `.tar.gz`
* Fixed shadow-ed distributions archive names as `<product>-<version>-shadow.<extension>`
* Added version to main distribution archive name as `<product>-<version>.<extension>` (but was it intentionaly removed? > @akirakw)
