### PR TITLE
feat(tgdump): enrich session information.

### DIFF
--- a/modules/common/connection/src/main/java/com/tsurugidb/tools/common/connection/ConnectionProvider.java
+++ b/modules/common/connection/src/main/java/com/tsurugidb/tools/common/connection/ConnectionProvider.java
@@ -119,7 +119,8 @@ public class ConnectionProvider {
         LOG.trace("enter: attempt: {} ({})", credential, settings); //$NON-NLS-1$
         var builder = SessionBuilder.connect(settings.getEndpointUri());
         builder.withCredential(credential);
-        // TODO: more settings
+        settings.getApplicationName().ifPresent(builder::withApplicationName);
+        settings.getSessionLabel().ifPresent(builder::withLabel);
         var timeout = settings.getEstablishTimeout();
         Session result;
         if (timeout.isEmpty()) {


### PR DESCRIPTION
This PR enables to pass application name and label to `tgdump` session.
Note that, `tgdump` already have been accepted such information (see [Main.java](https://github.com/project-tsurugi/tanzawa/blob/0344639618ece682264426bcefb4ad9eced4ad14/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/Main.java#L187-L188)), but at that time Tsubakuro did not support.