### PR TITLE
build: fix to exclude licese plugin to generated sources

### DIFF
--- a/modules/tgsql/core/build.gradle
+++ b/modules/tgsql/core/build.gradle
@@ -42,3 +42,11 @@ test {
 tasks.licenseMain {
     dependsOn 'generateJflex'
 }
+
+tasks.licenseFormatMain {
+    dependsOn 'generateJflex'
+}
+
+license {
+    exclude '**/SqlScannerFlex.java'
+}


### PR DESCRIPTION
This PR fixes to exlude automatically generated sources by Flex for Gradle License Plugin.