### PR TITLE
fix: always print stacktrace on tgdump errors.

### DIFF
--- a/modules/common/monitoring/src/main/java/com/tsurugidb/tools/common/monitoring/LoggingMonitor.java
+++ b/modules/common/monitoring/src/main/java/com/tsurugidb/tools/common/monitoring/LoggingMonitor.java
@@ -70,10 +70,10 @@ public class LoggingMonitor implements Monitor {
         Objects.requireNonNull(code);
         Objects.requireNonNull(arguments);
         if (cause == null) {
-            logger.info("failure: application={}, reason={}, message={}", //$NON-NLS-1$
+            logger.error("failure: application={}, reason={}, message={}", //$NON-NLS-1$
                     application, code, code.getMessage(arguments));
         } else {
-            logger.info("failure: application={}, reason={}, message={}", //$NON-NLS-1$
+            logger.error("failure: application={}, reason={}, message={}", //$NON-NLS-1$
                     application, code, code.getMessage(arguments),
                     cause);
         }
@@ -82,7 +82,7 @@ public class LoggingMonitor implements Monitor {
     @Override
     public void onFailure(@Nonnull DiagnosticException exception) {
         Objects.requireNonNull(exception);
-        logger.info("failure: application={}, reason={}, message={}", application, //$NON-NLS-1$
+        logger.error("failure: application={}, reason={}, message={}", application, //$NON-NLS-1$
                 application,
                 exception.getDiagnosticCode(),
                 exception.getDiagnosticCode().getMessage(exception.getArguments()),

--- a/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/Main.java
+++ b/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/Main.java
@@ -146,21 +146,19 @@ public class Main {
                         new BasicDumpMonitor(monitor)));
                 executeBody(dumpMonitor, arguments);
             } catch (DiagnosticException e) {
-                LOG.debug("diagnostic error", e);
                 LOG.error("{} - {}", e.getDiagnosticCode().getTag(), e.getMessage());
                 monitor.onFailure(e);
                 return Constants.EXIT_STATUS_OPERATION_ERROR;
             } catch (IOException e) {
-                LOG.error("I/O error was occurred", e);
+                LOG.error("{}", CliDiagnosticCode.IO_ERROR.getTag());
                 monitor.onFailure(e, CliDiagnosticCode.IO_ERROR, List.of(DiagnosticUtil.getMessage(e)));
                 return Constants.EXIT_STATUS_OPERATION_ERROR;
             } catch (InterruptedException e) {
-                LOG.debug("interrupted", e);
-                LOG.error("interrupted");
+                LOG.error("{}", CliDiagnosticCode.INTERRUPTED.getTag());
                 monitor.onFailure(e, CliDiagnosticCode.INTERRUPTED, List.of());
                 return Constants.EXIT_STATUS_INTERRUPTED;
             } catch (RuntimeException e) {
-                LOG.error("internal error", e);
+                LOG.error("{}", CliDiagnosticCode.INTERNAL.getTag());
                 monitor.onFailure(e, CliDiagnosticCode.INTERNAL, List.of(DiagnosticUtil.getMessage(e)));
                 return Constants.EXIT_STATUS_INTERNAL_ERROR;
             }


### PR DESCRIPTION
In this PR, `tgdump` now become to display stacktrace when the dump operation was failed, as `ERROR` log.

example:

```txt
[main] INFO com.tsurugidb.tools.tgdump.cli.Main - start: application=tgdump
[main] ERROR com.tsurugidb.tools.tgdump.cli.Main - io
[main] ERROR com.tsurugidb.tools.tgdump.cli.Main - failure: application=tgdump, reason=IO_ERROR, message=dump operation was failed by I/O error: IOException
java.io.IOException
	at (snip)
	at com.tsurugidb.tools.tgdump.cli.Main.execute(Main.java:147)
```