### PR TITLE
ci: modify runs-on for preventing ubuntu-latest

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       checks: write
     timeout-minutes: 30

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -5,7 +5,7 @@ concurrency: ${{ github.workflow }}
 
 jobs:
   Publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     timeout-minutes: 30


### PR DESCRIPTION
As ubuntu 24.04 is currently still experimental support

See: https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#ubuntu-latest-upcoming-breaking-changes