### PR TITLE
Parser can skip documentation comments individually.

### DIFF
--- a/modules/tgsql/cli/build.gradle
+++ b/modules/tgsql/cli/build.gradle
@@ -40,7 +40,10 @@ application {
 
 run {
     description 'run SQL script : -Dscript=</path/to/script> -Dconnection=<endpoint-uri> [-DlogLevel=<level>]'
-    args = [ System.getProperty('script', '(unspecified)'), System.getProperty('connection', 'unspecified:unspecified') ]
+    args = [
+        '--script', System.getProperty('script', '(unspecified)'),
+        '--connection', System.getProperty('connection', 'ipc:tsurugi'),
+    ]
     systemProperty 'org.slf4j.simpleLogger.defaultLogLevel', System.getProperty('logLevel', 'INFO')
     jvmArgs = ['--add-opens=java.base/java.nio=ALL-UNNAMED']
 }

--- a/modules/tgsql/core/src/main/java/com/tsurugidb/tgsql/core/parser/SqlParser.java
+++ b/modules/tgsql/core/src/main/java/com/tsurugidb/tgsql/core/parser/SqlParser.java
@@ -143,8 +143,9 @@ public class SqlParser implements Closeable {
 
         @Override
         public String toString() {
-            return String.format("{skipComments:%s}", //$NON-NLS-1$
-                    scannerOpts.skipRegularComments);
+            return String.format("{skipRegularComments:%s, skipDocumentationComments:%s}", //$NON-NLS-1$
+                    scannerOpts.skipRegularComments,
+                    scannerOpts.skipDocumentationComments);
         }
     }
 

--- a/modules/tgsql/core/src/main/java/com/tsurugidb/tgsql/core/parser/SqlParser.java
+++ b/modules/tgsql/core/src/main/java/com/tsurugidb/tgsql/core/parser/SqlParser.java
@@ -44,23 +44,71 @@ public class SqlParser implements Closeable {
         private final SqlScanner.Options scannerOpts = new SqlScanner.Options();
 
         /**
-         * Sets whether or not skip comment tokens.
+         * Sets whether to skip all comment tokens, including regular and documentation comments.
          * @param enabled {@code true} to skip comments, or {@code false} to treat comments as tokens
          * @return this
+         * @see #withSkipRegularComments(boolean)
+         * @see #withSkipDocumentationComments(boolean)
          * @see #DEFAULT_SKIP_COMMENTS
          */
         public Options withSkipComments(boolean enabled) {
-            this.scannerOpts.skipComments = enabled;
+            this.scannerOpts.skipRegularComments = enabled;
+            this.scannerOpts.skipDocumentationComments = enabled;
             return this;
         }
 
         /**
-         * Returns whether or not skip comment tokens.
-         * @return {@code true} to skip comments, or {@code false} to treat comments as tokens
+         * Returns whether or not skip all comment tokens.
+         * @return {@code true} to skip comments, or {@code false} to treat some comments as tokens
+         * @see #isSkipRegularComments()
+         * @see #isSkipDocumentationComments()
          * @see #DEFAULT_SKIP_COMMENTS
          */
         public boolean isSkipComments() {
-            return this.scannerOpts.skipComments;
+            return isSkipRegularComments() && isSkipDocumentationComments();
+        }
+
+        /**
+         * Sets whether to skip regular comments.
+         * <p>
+         * Even if this option is set to {@code true}, documentation comments are still effective.
+         * </p>
+         * @param enabled {@code true} to skip regular comments, or {@code false} to treat them as tokens
+         * @return this
+         * @see #withSkipDocumentationComments(boolean)
+         */
+        public Options withSkipRegularComments(boolean enabled) {
+            this.scannerOpts.skipRegularComments = enabled;
+            return this;
+        }
+
+        /**
+         * Returns whether to skip regular comments.
+         * @return {@code true} to skip regular comments, or {@code false} to treat them as tokens
+         * @see #isSkipDocumentationComments()
+         */
+        public boolean isSkipRegularComments() {
+            return this.scannerOpts.skipRegularComments;
+        }
+
+        /**
+         * Sets whether to skip documentation comments ({@code /&#42;&#42; .. &#42;/}).
+         * @param enabled {@code true} to skip documentation comments, or {@code false} to treat them as tokens
+         * @return this
+         * @see #withSkipRegularComments(boolean)
+         */
+        public Options withSkipDocumentationComments(boolean enabled) {
+            this.scannerOpts.skipDocumentationComments = enabled;
+            return this;
+        }
+
+        /**
+         * Returns whether to skip documentation comments.
+         * @return {@code true} to skip documentation comments, or {@code false} to treat them as tokens
+         * @see #isSkipRegularComments()
+         */
+        public boolean isSkipDocumentationComments() {
+            return this.scannerOpts.skipDocumentationComments;
         }
 
         @Override
@@ -96,7 +144,7 @@ public class SqlParser implements Closeable {
         @Override
         public String toString() {
             return String.format("{skipComments:%s}", //$NON-NLS-1$
-                    scannerOpts.skipComments);
+                    scannerOpts.skipRegularComments);
         }
     }
 

--- a/modules/tgsql/core/src/main/java/com/tsurugidb/tgsql/core/parser/SqlScanner.java
+++ b/modules/tgsql/core/src/main/java/com/tsurugidb/tgsql/core/parser/SqlScanner.java
@@ -34,13 +34,16 @@ class SqlScanner implements Closeable {
 
         static final boolean DEFAULT_SKIP_COMMENTS = false;
 
-        boolean skipComments = DEFAULT_SKIP_COMMENTS;
+        boolean skipRegularComments = DEFAULT_SKIP_COMMENTS;
+
+        boolean skipDocumentationComments = DEFAULT_SKIP_COMMENTS;
 
         @Override
         public int hashCode() {
             final int prime = 31;
             int result = 1;
-            result = prime * result + (skipComments ? 1231 : 1237);
+            result = prime * result + (skipRegularComments ? 1231 : 1237);
+            result = prime * result + (skipDocumentationComments ? 1231 : 1237);
             return result;
         }
 
@@ -56,7 +59,10 @@ class SqlScanner implements Closeable {
                 return false;
             }
             Options other = (Options) obj;
-            if (skipComments != other.skipComments) {
+            if (skipRegularComments != other.skipRegularComments) {
+                return false;
+            }
+            if (skipDocumentationComments != other.skipDocumentationComments) {
                 return false;
             }
             return true;
@@ -83,7 +89,10 @@ class SqlScanner implements Closeable {
     SqlScanner(@Nonnull Reader input, @Nonnull Options options) {
         Objects.requireNonNull(input);
         Objects.requireNonNull(options);
-        flex = new SqlScannerFlex(input, options.skipComments);
+        flex = new SqlScannerFlex(
+                input,
+                options.skipRegularComments,
+                options.skipDocumentationComments);
     }
 
     /**

--- a/modules/tgsql/core/src/test/java/com/tsurugidb/tgsql/core/parser/SqlParserTest.java
+++ b/modules/tgsql/core/src/test/java/com/tsurugidb/tgsql/core/parser/SqlParserTest.java
@@ -72,18 +72,44 @@ class SqlParserTest {
     }
 
     @Test
-    void comments() throws Exception {
-        var ss = parse("-- comment\nSELECT * FROM T");
+    void regular_comments() throws Exception {
+        var opts = new SqlParser.Options()
+                .withSkipRegularComments(false)
+                .withSkipDocumentationComments(true);
+        var ss = parse(opts, "-- comment\nSELECT * FROM T");
         assertEquals(1, ss.size());
         assertEquals(Statement.Kind.GENERIC, ss.get(0).getKind());
         assertEquals("-- comment\nSELECT * FROM T", ss.get(0).getText());
     }
 
     @Test
-    void comments_skip() throws Exception {
+    void regular_comments_skip() throws Exception {
         var opts = new SqlParser.Options()
-                .withSkipComments(true);
-        var ss = parse(opts, "-- comment\nSELECT * FROM T");
+                .withSkipRegularComments(true)
+                .withSkipDocumentationComments(true);
+        var ss = parse(opts, "/* regular comment */\nSELECT * FROM T");
+        assertEquals(1, ss.size());
+        assertEquals(Statement.Kind.GENERIC, ss.get(0).getKind());
+        assertEquals("SELECT * FROM T", ss.get(0).getText());
+    }
+
+    @Test
+    void documentation_comments() throws Exception {
+        var opts = new SqlParser.Options()
+                .withSkipRegularComments(true)
+                .withSkipDocumentationComments(false);
+        var ss = parse(opts, "/** doc comment */\nSELECT * FROM T");
+        assertEquals(1, ss.size());
+        assertEquals(Statement.Kind.GENERIC, ss.get(0).getKind());
+        assertEquals("/** doc comment */\nSELECT * FROM T", ss.get(0).getText());
+    }
+
+    @Test
+    void documentation_comments_skip() throws Exception {
+        var opts = new SqlParser.Options()
+                .withSkipRegularComments(false)
+                .withSkipDocumentationComments(true);
+        var ss = parse(opts, "/** doc comment */\nSELECT * FROM T");
         assertEquals(1, ss.size());
         assertEquals(Statement.Kind.GENERIC, ss.get(0).getKind());
         assertEquals("SELECT * FROM T", ss.get(0).getText());

--- a/modules/tgsql/core/src/test/java/com/tsurugidb/tgsql/core/parser/SqlScannerTest.java
+++ b/modules/tgsql/core/src/test/java/com/tsurugidb/tgsql/core/parser/SqlScannerTest.java
@@ -230,7 +230,7 @@ class SqlScannerTest {
     @Test
     void block_comment_skip() throws Exception {
         var opts = new SqlScanner.Options();
-        opts.skipComments = true;
+        opts.skipRegularComments = true;
         var s = scanOne(
                 opts,
                 "SELECT",
@@ -260,7 +260,7 @@ class SqlScannerTest {
     @Test
     void slash_comment_skip() throws Exception {
         var opts = new SqlScanner.Options();
-        opts.skipComments = true;
+        opts.skipRegularComments = true;
         var s = scanOne(
                 opts,
                 "// just returns 1",
@@ -288,11 +288,46 @@ class SqlScannerTest {
     @Test
     void hyphen_comment_skip() throws Exception {
         var opts = new SqlScanner.Options();
-        opts.skipComments = true;
+        opts.skipRegularComments = true;
         var s = scanOne(
                 opts,
                 "-- just returns 1",
                 "SELECT 1");
+        assertEquals(List.of(
+                TokenKind.REGULAR_IDENTIFIER,
+                TokenKind.NUMERIC_LITERAL,
+                TokenKind.END_OF_STATEMENT), kinds(s));
+        assertEquals(0, s.getComments().size());
+    }
+
+    @Test
+    void documentation_comment() throws Exception {
+        var opts = new SqlScanner.Options();
+        opts.skipRegularComments = true;
+        var s = scanOne(
+                opts,
+                "SELECT",
+                "/**",
+                " * TESTING",
+                " */ 1");
+        assertEquals(List.of(
+                TokenKind.REGULAR_IDENTIFIER,
+                TokenKind.NUMERIC_LITERAL,
+                TokenKind.END_OF_STATEMENT), kinds(s));
+        assertEquals(1, s.getComments().size());
+        assertEquals(TokenKind.BLOCK_COMMENT, s.getComments().get(0).getKind());
+    }
+
+    @Test
+    void documentation_comment_skip() throws Exception {
+        var opts = new SqlScanner.Options();
+        opts.skipDocumentationComments = true;
+        var s = scanOne(
+                opts,
+                "SELECT",
+                "/**",
+                " * TESTING",
+                " */ 1");
         assertEquals(List.of(
                 TokenKind.REGULAR_IDENTIFIER,
                 TokenKind.NUMERIC_LITERAL,


### PR DESCRIPTION
This PR introcues a new API for control SQL parser:

* `SqlParser.Option.withSkipRegularComments()`
  * skip comments except doc comments (`--` and `/* .. */` excpet `/** ... */`)
* `SqlParser.Option.withSkipDocumentationComments()`
  * skip doc comments (`/** ... */`)
* `SqlParser.Option.withSkipComments()` (existing)
  * skip all comments
