### PR TITLE
feat(tgdump): introduce `--scan-parallel` option

### DIFF
--- a/docs/tgdump-design_ja.md
+++ b/docs/tgdump-design_ja.md
@@ -92,10 +92,16 @@ tgdump --sql [<query-label>:]<query-text> [[<query-label>:]<query-text> [...]] -
   * `--transaction-label`
     * トランザクションのラベル
     * 未指定の場合はラベルを利用しない
+  * `--scan-parallel`
+    * データベース側のテーブル読み出しの最大タスク分割数
+      * 現状は RTX のみで有効
+    * 未指定の場合は、データベースのデフォルト設定を利用
   * `--threads`
     * クライアント側の処理スレッド数
       * サーバ側に同時に処理を要求するテーブル数はこのスレッド数に制限される
     * 未指定の場合は `1`
+    * Attention: 同一セッション内で、同時に利用可能な出力チャネル数に制限に抵触する可能性がある
+      * 原則的には、 `--scan-parallel` の値と `--threads` の値の積が出力チャネル数 (`sql.max_result_set_writers`) の上限を超えないようにすること
   * `-v,--verbose`
     * より多くのメッセージを標準出力へ出力する
   * `--monitor` (hidden)
@@ -275,10 +281,6 @@ tgdump --sql [<query-label>:]<query-text> [[<query-label>:]<query-text> [...]] -
   `internal` | 非 `0` | アプリケーション側の問題による内部エラー
 
   ※ reason はモニタリング情報のコマンド終了時の原因コード、 exit status はコマンド自体の終了ステータス
-
-* 備考
-  * TBD: strand 前提で、テーブルごとの最大ダンプ並列数を指定できるようにする
-    * `-P,--parallel` あたりを想定
 
 ## ダンププロファイル
 

--- a/modules/tgdump/README.md
+++ b/modules/tgdump/README.md
@@ -106,6 +106,10 @@ Optional Parameters:
 * `--transaction-label`
   * The transaction label.
   * Default: no transaction labels.
+* `--scan-parallel`
+  * The maximum task division number for table reading on the database side.
+    * Currently only effective for RTX.
+  * Default: follows the database default.
 * `--threads`
   * The number of client threads used for export operations.
     * The number of tables or queries processed simultaneously is limited by this value.

--- a/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/CommandArgumentSet.java
+++ b/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/CommandArgumentSet.java
@@ -65,6 +65,21 @@ public class CommandArgumentSet {
     }
 
     /**
+     * A validator to ensure zero or more parameter values.
+     */
+    public static class ZeroOrMoreValidator implements IValueValidator<Integer> {
+        @Override
+        public void validate(String name, Integer value) throws ParameterException {
+            if (value < 0) {
+                throw new ParameterException(MessageFormat.format(
+                        "\"{0}\" must be >= 0 (specified: {1})",
+                        name,
+                        value));
+            }
+        }
+    }
+
+    /**
      * A validator to ensure one or more parameter values.
      */
     public static class OneOrMoreValidator implements IValueValidator<Integer> {
@@ -185,6 +200,8 @@ public class CommandArgumentSet {
     private String transactionLabel = null;
 
     private int numberOfWorkerThreads = DEFAULT_NUMBER_OF_WORKER_THREADS;
+
+    private Integer numberOfScanParallels = null;
 
     private String authenticationUser = null;
 
@@ -555,6 +572,36 @@ public class CommandArgumentSet {
     public void setTransactionLabel(@Nullable String label) {
         LOG.trace("argument: --transaction-label: {}", label); //$NON-NLS-1$
         this.transactionLabel = label;
+    }
+
+    /**
+     * Returns the number of scan parallels for reading tables.
+     * @return the number of scan parallels, or {@code null} if it is not specified
+     */
+    public Integer getNumberOfScanParallels() {
+        return numberOfScanParallels;
+    }
+
+    /**
+     * Sets the number of scan parallels for reading tables.
+     * @param count the number of scan parallels, or {@code null} to clear it
+     * @throws IllegalArgumentException if the value is less than {@code 0}
+     */
+    @Parameter(
+            order = 120,
+            names = { "--scan-parallel" },
+            arity = 1,
+            description = "The number of scan parallels for reading tables",
+            validateValueWith = ZeroOrMoreValidator.class,
+            required = false)
+    public void setNumberOfScanParallels(@Nullable Integer count) {
+        if (count != null && count < 0) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "the number of scan parallels must be > 0 (specified: {0})",
+                    count));
+        }
+        LOG.trace("argument: --scan-parallel: {}", count); //$NON-NLS-1$
+        this.numberOfScanParallels = count;
     }
 
 

--- a/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/CommandUtil.java
+++ b/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/CommandUtil.java
@@ -101,6 +101,7 @@ final class CommandUtil {
         printArgument(printer, "--transaction", args.getTransactionType()); //$NON-NLS-1$
         printArgument(printer, "--transaction-label", args.getTransactionLabel()); //$NON-NLS-1$
         printArgument(printer, "--threads", args.getNumberOfWorkerThreads()); //$NON-NLS-1$
+        printArgument(printer, "--scan-parallel", args.getNumberOfScanParallels()); //$NON-NLS-1$
 
         // information settings
         printArgument(printer, "--verbose", args.isVerbose()); //$NON-NLS-1$

--- a/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/Main.java
+++ b/modules/tgdump/cli/src/main/java/com/tsurugidb/tools/tgdump/cli/Main.java
@@ -213,6 +213,7 @@ public class Main {
         var transactionSettings = TransactionSettings.newBuilder()
                 .withType(args.getTransactionType())
                 .withLabel(args.getTransactionLabel())
+                .withScanParallel(args.getNumberOfScanParallels())
                 .build();
         var engine = new DumpEngine(args.getNumberOfWorkerThreads());
         var profile = CommandUtil.loadProfile(args.getProfileBundleLoader(), args.getProfile());

--- a/modules/tgdump/cli/src/test/java/com/tsurugidb/tools/tgdump/cli/MainTest.java
+++ b/modules/tgdump/cli/src/test/java/com/tsurugidb/tools/tgdump/cli/MainTest.java
@@ -512,6 +512,32 @@ class MainTest {
     }
 
     @Test
+    void parseArguments_scan_parallel() {
+        var app = new Main();
+        var args = app.parseArguments(
+                "--connection", "ipc:testing", "A", "--to", "output",
+                "--scan-parallel", "4");
+        assertEquals(4, args.getNumberOfScanParallels());
+    }
+
+    @Test
+    void parseArguments_scan_parallel_zero() {
+        var app = new Main();
+        var args = app.parseArguments(
+                "--connection", "ipc:testing", "A", "--to", "output",
+                "--scan-parallel", "0");
+        assertEquals(0, args.getNumberOfScanParallels());
+    }
+
+    @Test
+    void parseArguments_scan_parallel_invalid() {
+        var app = new Main();
+        assertThrows(ParameterException.class, () -> app.parseArguments(
+                "--connection", "ipc:testing", "A", "--to", "output",
+                "--scan-parallel", "-1"));
+    }
+
+    @Test
     void parseArguments_monitor() {
         var app = new Main();
         var args = app.parseArguments(

--- a/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/TransactionSettings.java
+++ b/modules/tgdump/core/src/main/java/com/tsurugidb/tools/tgdump/core/model/TransactionSettings.java
@@ -19,8 +19,10 @@ import java.text.MessageFormat;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.tsurugidb.sql.proto.SqlRequest;
 
@@ -57,9 +59,11 @@ public class TransactionSettings {
 
         Type type = DEFAULT_TYPE;
 
-        String label;
+        @Nullable String label;
 
         boolean enableReadAreas = DEFAULT_ENABLE_READ_AREAS;
+
+        @Nullable Integer scanParallel;
 
         /**
          * Creates a new instance from this builder settings.
@@ -99,6 +103,22 @@ public class TransactionSettings {
             this.enableReadAreas = value;
             return this;
         }
+
+        /**
+         * Sets the scan parallel value.
+         * @param value the value to set, or {@code null} to clear the setting
+         * @return this
+         * @throws IllegalArgumentException if the given value is negative ({@code < 0})
+         */
+        public Builder withScanParallel(Integer value) {
+            if (value != null && value < 0) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "scan parallel must be >= 0: {0}",
+                        value));
+            }
+            this.scanParallel = value;
+            return this;
+        }
     }
 
     /**
@@ -116,6 +136,8 @@ public class TransactionSettings {
     private final String label;
 
     private final boolean enableReadAreas;
+
+    private final Integer scanParallel;
 
     /**
      * Creates a new instance with default settings.
@@ -135,6 +157,7 @@ public class TransactionSettings {
         this.type = builder.type;
         this.label = builder.label;
         this.enableReadAreas = builder.enableReadAreas;
+        this.scanParallel = builder.scanParallel;
     }
 
     /**
@@ -170,6 +193,17 @@ public class TransactionSettings {
     }
 
     /**
+     * Returns the scan parallel value.
+     * @return the scan parallel value, or empty if it is not set
+     */
+    public OptionalInt getScanParallel() {
+        if (scanParallel == null) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(scanParallel);
+    }
+
+    /**
      * Builds transaction options from this settings.
      * @param tables the source tables
      * @return the built protocol buffer object
@@ -199,12 +233,13 @@ public class TransactionSettings {
                     txType));
         }
         getLabel().ifPresent(options::setLabel);
+        getScanParallel().ifPresent(options::setScanParallel);
         return options.build();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enableReadAreas, label, type);
+        return Objects.hash(enableReadAreas, label, type, scanParallel);
     }
 
     @Override
@@ -219,11 +254,14 @@ public class TransactionSettings {
             return false;
         }
         TransactionSettings other = (TransactionSettings) obj;
-        return enableReadAreas == other.enableReadAreas && Objects.equals(label, other.label) && type == other.type;
+        return enableReadAreas == other.enableReadAreas
+            && Objects.equals(label, other.label)
+            && type == other.type
+            && Objects.equals(scanParallel, other.scanParallel);
     }
 
     @Override
     public String toString() {
-        return String.format("TransactionSettings(type=%s, label=%s)", type, label); //$NON-NLS-1$
+        return String.format("TransactionSettings(type=%s, label=%s, scanParallel=%s)", type, label, scanParallel);
     }
 }

--- a/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/TransactionSettingsTest.java
+++ b/modules/tgdump/core/src/test/java/com/tsurugidb/tools/tgdump/core/model/TransactionSettingsTest.java
@@ -15,10 +15,11 @@
  */
 package com.tsurugidb.tools.tgdump.core.model;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,7 @@ class TransactionSettingsTest {
         assertEquals(TransactionSettings.DEFAULT_TYPE, s.getType());
         assertEquals(Optional.empty(), s.getLabel());
         assertEquals(TransactionSettings.DEFAULT_ENABLE_READ_AREAS, s.isEnableReadAreas());
+        assertEquals(OptionalInt.empty(), s.getScanParallel());
 
         assertEquals(s, new TransactionSettings(), s.toString());
         assertEquals(
@@ -40,6 +42,20 @@ class TransactionSettingsTest {
                         .setType(SqlRequest.TransactionType.READ_ONLY)
                         .build(),
                 s.toProtocolBuffer(List.of()));
+    }
+
+    @Test
+    void withScanParallel_zero() {
+        var s = TransactionSettings.newBuilder()
+                .withScanParallel(0)
+                .build();
+        assertEquals(OptionalInt.of(0), s.getScanParallel());
+    }
+
+    @Test
+    void withScanParallel_negative() {
+        var b = TransactionSettings.newBuilder();
+        assertThrows(IllegalArgumentException.class, () -> b.withScanParallel(-1));
     }
 
     @Test
@@ -103,5 +119,33 @@ class TransactionSettingsTest {
                         .setLabel("TESTING")
                         .build(),
                 s.toProtocolBuffer(List.of("T1")));
+    }
+
+    @Test
+    void toProtocolBuffer_label() {
+        var s = TransactionSettings.newBuilder()
+                .withLabel("TESTING")
+                .build();
+        assertEquals(Optional.of("TESTING"), s.getLabel());
+        assertEquals(
+                SqlRequest.TransactionOption.newBuilder()
+                        .setType(SqlRequest.TransactionType.READ_ONLY)
+                        .setLabel("TESTING")
+                        .build(),
+                s.toProtocolBuffer(List.of()));
+    }
+
+    @Test
+    void toProtocolBuffer_scanParallel() {
+        var s = TransactionSettings.newBuilder()
+                .withScanParallel(4)
+                .build();
+        assertEquals(OptionalInt.of(4), s.getScanParallel());
+        assertEquals(
+                SqlRequest.TransactionOption.newBuilder()
+                        .setType(SqlRequest.TransactionType.READ_ONLY)
+                        .setScanParallel(4)
+                        .build(),
+                s.toProtocolBuffer(List.of()));
     }
 }


### PR DESCRIPTION
This pull request adds support for configuring the maximum number of parallel tasks for table scans in the `tgdump` tool via a new `--scan-parallel` option. This allows users to control how many parallel scan operations the database should perform, complementing the existing client-side threading options. The changes include updates to documentation, CLI argument parsing and validation, core model propagation, and test coverage for the new parameter.

**New parameter support and propagation:**

* Added a new CLI option `--scan-parallel` to specify the maximum number of parallel scan tasks for table reads, including validation to ensure non-negative values and documentation updates in both English and Japanese manuals. [[1]](diffhunk://#diff-db60da0c7f268ec3538c2ece3e8f4e038f32d4850bb43566c3454a856643c9b8R95-R104) [[2]](diffhunk://#diff-a5ceebd72c6de881e1f7f0634245879525e5dd81343c5ade32383ea3bc7e914cR109-R112) [[3]](diffhunk://#diff-6faa3bcbf7be06033313f875243983d7a5c225e9834fd0a3b91bf7ab23a50fbbR577-R606)
* Extended the `CommandArgumentSet` class to store and validate the new parameter, including a `ZeroOrMoreValidator` for non-negative integer enforcement. [[1]](diffhunk://#diff-6faa3bcbf7be06033313f875243983d7a5c225e9834fd0a3b91bf7ab23a50fbbR67-R81) [[2]](diffhunk://#diff-6faa3bcbf7be06033313f875243983d7a5c225e9834fd0a3b91bf7ab23a50fbbR204-R205)
* Updated the `TransactionSettings` core model to accept, store, and propagate the `scanParallel` value, ensuring it is included in protocol buffer serialization and equality/hash logic. [[1]](diffhunk://#diff-dea10925be89fdcec3d072d6f4bace3bc21454029655512bec81aff8c1573150R22-R25) [[2]](diffhunk://#diff-dea10925be89fdcec3d072d6f4bace3bc21454029655512bec81aff8c1573150L60-R67) [[3]](diffhunk://#diff-dea10925be89fdcec3d072d6f4bace3bc21454029655512bec81aff8c1573150R106-R121) [[4]](diffhunk://#diff-dea10925be89fdcec3d072d6f4bace3bc21454029655512bec81aff8c1573150R140-R141) [[5]](diffhunk://#diff-dea10925be89fdcec3d072d6f4bace3bc21454029655512bec81aff8c1573150R160) [[6]](diffhunk://#diff-dea10925be89fdcec3d072d6f4bace3bc21454029655512bec81aff8c1573150R195-R205) [[7]](diffhunk://#diff-dea10925be89fdcec3d072d6f4bace3bc21454029655512bec81aff8c1573150R236-R242) [[8]](diffhunk://#diff-dea10925be89fdcec3d072d6f4bace3bc21454029655512bec81aff8c1573150L222-R265)
* Modified the main execution flow to pass the new parameter from CLI arguments to transaction settings.

**Testing and utility updates:**

* Added comprehensive unit tests for parsing, validation, and propagation of the `--scan-parallel` option, including edge cases for zero and negative values. [[1]](diffhunk://#diff-7b7f3495caf0a620071399aa0d10e0d027b17b40baaef740c8889ab6ea2ededeR514-R539) [[2]](diffhunk://#diff-271484c34683ec623f886b6a6e8ebbdc7f9fa7c075ca0896109c100664fbaaa4L18-R22) [[3]](diffhunk://#diff-271484c34683ec623f886b6a6e8ebbdc7f9fa7c075ca0896109c100664fbaaa4R37) [[4]](diffhunk://#diff-271484c34683ec623f886b6a6e8ebbdc7f9fa7c075ca0896109c100664fbaaa4R47-R60) [[5]](diffhunk://#diff-271484c34683ec623f886b6a6e8ebbdc7f9fa7c075ca0896109c100664fbaaa4R123-R150)
* Updated argument printing utilities to display the new option for better traceability in logs and diagnostics.

**Documentation and cleanup:**

* Improved documentation to describe the new option and its interaction with threading and output channel limits, and removed obsolete notes about future parallelism options.

These changes provide users with finer control over database-side parallelism for table scans, while ensuring robust validation, clear documentation, and consistent propagation throughout the tool.