### PR TITLE
build: migrate and bump Gradle shadow plugin

### DIFF
--- a/modules/tgdump/cli/build.gradle
+++ b/modules/tgdump/cli/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'tanzawa.java-conventions'
     id 'application'
-    id 'io.github.goooler.shadow' version '8.1.8'
+    id 'com.gradleup.shadow' version '8.3.9'
 }
 
 dependencies {

--- a/modules/tgsql/cli/build.gradle
+++ b/modules/tgsql/cli/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'tanzawa.java-conventions'
     id 'application'
-    id 'io.github.goooler.shadow' version '8.1.8'
+    id 'com.gradleup.shadow' version '8.3.9'
 }
 
 dependencies {


### PR DESCRIPTION
This PR migrates to the official GradleUp-maintained Shadow plugin (com.gradleup.shadow) and bumps the version to 8.3.9.